### PR TITLE
seeDisguise

### DIFF
--- a/src/ESP/EspPlayerPatches.cs
+++ b/src/ESP/EspPlayerPatches.cs
@@ -44,4 +44,29 @@ public static class ESP_ChatBubblePostfix
         __instance.NameText.color = Utils.getColorName(CheatSettings.seeRoles, __instance.playerInfo);
     
     }
-}    
+}
+
+[HarmonyPatch(typeof(PlayerControl), nameof(PlayerControl.RawSetOutfit))]
+public static class ESP_PlayerControlRawSetOutfitPostfix
+{
+    public static void Postfix(PlayerControl __instance, [HarmonyArgument(0)] GameData.PlayerOutfit newOutfit,
+        PlayerOutfitType type)
+    {
+        if (CheatSettings.seeDisguise)
+        {
+            if (type == PlayerOutfitType.Shapeshifted)
+            {
+                if (__instance.AmOwner) return;
+                __instance.Shapeshift(__instance, false);
+                HudManager.Instance.Notifier.AddItem($"{__instance.Data.PlayerName} =Shapeshift=> {newOutfit.PlayerName}, Reverted");
+            }
+
+            if (type == PlayerOutfitType.MushroomMixup)
+            {
+                __instance.FixMixedUpOutfit();
+                //This will cause player name not showing, pls help.
+                //Help me add a correct notifier
+            }
+        }
+    }
+}

--- a/src/UI/CheatSettings.cs
+++ b/src/UI/CheatSettings.cs
@@ -17,6 +17,7 @@ namespace MalumMenu
         public static bool fullBright;
         public static bool seeGhosts;
         public static bool seeRoles;
+        public static bool seeDisguise;
 
         //Camera
         public static bool spectate;

--- a/src/UI/MenuUI.cs
+++ b/src/UI/MenuUI.cs
@@ -26,7 +26,8 @@ public class MenuUI : MonoBehaviour
             new ToggleInfo(" SeeGhosts", () => CheatSettings.seeGhosts, x => CheatSettings.seeGhosts = x),
             new ToggleInfo(" SeeRoles", () => CheatSettings.seeRoles, x => CheatSettings.seeRoles = x),
             new ToggleInfo(" AlwaysChat", () => CheatSettings.alwaysChat, x => CheatSettings.alwaysChat = x),
-            new ToggleInfo(" FullBright", () => CheatSettings.fullBright, x => CheatSettings.fullBright = x)
+            new ToggleInfo(" FullBright", () => CheatSettings.fullBright, x => CheatSettings.fullBright = x),
+            new ToggleInfo(" seeDisguise", () => CheatSettings.seeDisguise, x => CheatSettings.seeDisguise = x),
         }));
 
         groups.Add(new GroupInfo("Camera", false, new List<ToggleInfo>() {


### PR DESCRIPTION
Patch setrawoutfit postfix
1. Unshapeshift upon shapeshift
2. do PlayerControl.fixmixupoutfit to revert mushroom shapeshift

Existing Problem:
1. Add a proper notifier for mushroom mixup outfit
2. Use fixmixupoutfit will cause player name not showing after un shapeshift & after mushroom sabotage ended