### PR TITLE
updated chat character length color indicator

### DIFF
--- a/src/Chat/ChatJailbreakPatch.cs
+++ b/src/Chat/ChatJailbreakPatch.cs
@@ -156,7 +156,7 @@ public static class ChatJailbreak_UpdateCharCountPostfix
     public static void Postfix(FreeChatInputField __instance)
     {
 	if (!CheatSettings.chatJailbreak){
-            return true; //Only works if CheatSettings.chatJailbreak is enabled
+            return; //Only works if CheatSettings.chatJailbreak is enabled
         }
         int length = __instance.textArea.text.Length;
         __instance.charCountText.SetText($"{length}/{__instance.textArea.characterLimit}");

--- a/src/Chat/ChatJailbreakPatch.cs
+++ b/src/Chat/ChatJailbreakPatch.cs
@@ -147,3 +147,24 @@ public static class ChatJailbreak_IsCharAllowedPostfix
         return false;
     }
 }
+
+
+// Edit Color indicators for chatbox (only visual)
+[HarmonyPatch(typeof(FreeChatInputField), nameof(FreeChatInputField.UpdateCharCount))]
+public static class ChatJailbreak_UpdateCharCountPostfix
+{
+    public static void Postfix(FreeChatInputField __instance)
+    {
+        int length = __instance.textArea.text.Length;
+        __instance.charCountText.SetText($"{length}/{__instance.textArea.characterLimit}");
+        if (length < 1825361100)
+            // Black if not close to limit
+            __instance.charCountText.color = Color.black;
+        else if (length < 2147483647)
+            // Yellow if close to limit
+            __instance.charCountText.color = new Color(1f, 1f, 0f, 1f);
+        else
+            // Red if limit reached
+            __instance.charCountText.color = Color.red;
+    }
+}

--- a/src/Chat/ChatJailbreakPatch.cs
+++ b/src/Chat/ChatJailbreakPatch.cs
@@ -155,16 +155,16 @@ public static class ChatJailbreak_UpdateCharCountPostfix
 {
     public static void Postfix(FreeChatInputField __instance)
     {
+	if (!CheatSettings.chatJailbreak){
+            return true; //Only works if CheatSettings.chatJailbreak is enabled
+        }
         int length = __instance.textArea.text.Length;
         __instance.charCountText.SetText($"{length}/{__instance.textArea.characterLimit}");
-        if (length < 1825361100)
-            // Black if not close to limit
+        if (length < 1610612735) // Black if not close to limit
             __instance.charCountText.color = Color.black;
-        else if (length < 2147483647)
-            // Yellow if close to limit
+        else if (length < 2147483647) // Yellow if close to limit
             __instance.charCountText.color = new Color(1f, 1f, 0f, 1f);
-        else
-            // Red if limit reached
+        else // Red if limit reached
             __instance.charCountText.color = Color.red;
     }
 }


### PR DESCRIPTION
Right now, if we write 75 characters, the indicator on top of the chat box (75/100) turns yellow. if we hit 100 characters, it turns red. 

But with chatJailbreak enabled, we have a limit of 2147483647 characters. 

I edited the method that updates the indicator so that it turns yellow on 75% of the limit which is approx. 1610612735 and turns red on 2147483647.
