### PR TITLE
TODO

### DIFF
--- a/src/ESP/EspCheatsPatches.cs
+++ b/src/ESP/EspCheatsPatches.cs
@@ -44,10 +44,10 @@ public static class SeeRoles_ChatBubble_SetName_Postfix
 {
     //Postfix patch of ChatBubble.SetName to get colored names in chat messages
     public static void Postfix(ChatBubble __instance){
-
-        //Get appropriate name color depending on if CheatSettings.seeRoles is enabled
-        __instance.NameText.text = Utils.getNameTag(__instance.playerInfo.Object, __instance.playerInfo.PlayerName, true);
-    
+        if (CheatToggles.seeRoles)
+        {
+            __instance.NameText.text = Utils.getNameTag(__instance.playerInfo.Object, __instance.playerInfo.PlayerName, true);
+        }
     }
 }    
 

--- a/src/ESP/EspCheatsPatches.cs
+++ b/src/ESP/EspCheatsPatches.cs
@@ -12,12 +12,14 @@ public static class SeeRoles_PlayerPhysics_LateUpdate_Postfix
     //Postfix patch of PlayerPhysics.LateUpdate to get colored names in-game 
     public static void Postfix(PlayerPhysics __instance){
         //try-catch to prevent errors when role is null
-        try{
+        try
+        {
 
             //Get appropriate name color depending on if CheatSettings.seeRoles is enabled
             __instance.myPlayer.cosmetics.SetName(Utils.getNameTag(__instance.myPlayer, __instance.myPlayer.CurrentOutfit.PlayerName));
-            
-        }catch{}
+
+        }
+        catch { }
     }
 }    
 
@@ -48,10 +50,10 @@ public static class SeeRoles_ChatBubble_SetName_Postfix
 {
     //Postfix patch of ChatBubble.SetName to get colored names in chat messages
     public static void Postfix(ChatBubble __instance){
-        if (CheatToggles.seeRoles)
+        if (CheatToggles.seeRoles && !CheatChecks.isLobby)
         {
             var player = __instance.playerInfo.Object;
-            __instance.NameText.text = $"<color=#{ColorUtility.ToHtmlStringRGB(player.Data.Role.TeamColor)}><size=70%>{Utils.getRoleNameTranslated(player.Data.Role)}</size></color> " + __instance.NameText.text;
+            __instance.NameText.text = $"<color=#{ColorUtility.ToHtmlStringRGB(player.Data.Role.TeamColor)}><size=70%>{Utils.getRoleNameTranslated(player.Data)}</size></color> " + __instance.NameText.text;
             __instance.NameText.ForceMeshUpdate(true, true);
             __instance.Background.size = new Vector2(5.52f, 0.2f + __instance.NameText.GetNotDumbRenderedHeight() + __instance.TextArea.GetNotDumbRenderedHeight());
             __instance.MaskArea.size = __instance.Background.size - new Vector2(0f, 0.03f);
@@ -245,7 +247,7 @@ public static class SeeUserInfo_PlayerPhysics_LateUpdate_Postfix
                     break;
             }
             var playerName = __instance.myPlayer.cosmetics.nameText.text;
-            playerName = "<size=50%>Level: <#0f0>" + __instance.myPlayer.Data.PlayerLevel + "</color>\r\nPlatform: <#0f0><u>" + platform + "</u></color></size>\r\n" + playerName;
+            playerName = "<size=50%>Level: <#0f0>" + __instance.myPlayer.Data.PlayerLevel + "</color>\r\nPlatform: <#0f0>" + platform + "</color></size>\r\n" + playerName;
             __instance.myPlayer.cosmetics.SetName(playerName);
         }
     }

--- a/src/ESP/EspCheatsPatches.cs
+++ b/src/ESP/EspCheatsPatches.cs
@@ -50,10 +50,10 @@ public static class SeeRoles_ChatBubble_SetName_Postfix
 {
     //Postfix patch of ChatBubble.SetName to get colored names in chat messages
     public static void Postfix(ChatBubble __instance){
-        if (CheatToggles.seeRoles && !CheatChecks.isLobby)
+        if (CheatToggles.seeRoles)
         {
             var player = __instance.playerInfo.Object;
-            __instance.NameText.text = $"<color=#{ColorUtility.ToHtmlStringRGB(player.Data.Role.TeamColor)}><size=70%>{Utils.getRoleNameTranslated(player.Data)}</size></color> " + __instance.NameText.text;
+            __instance.NameText.text = $"<color=#{ColorUtility.ToHtmlStringRGB(player.Data.Role.TeamColor)}><size=70%>{Utils.getRoleName(player.Data)}</size></color> " + __instance.NameText.text;
             __instance.NameText.ForceMeshUpdate(true, true);
             __instance.Background.size = new Vector2(5.52f, 0.2f + __instance.NameText.GetNotDumbRenderedHeight() + __instance.TextArea.GetNotDumbRenderedHeight());
             __instance.MaskArea.size = __instance.Background.size - new Vector2(0f, 0.03f);
@@ -201,54 +201,5 @@ public static class SporeVision_Mushroom_FixedUpdate_Postfix
         } 
 
         __instance.sporeMask.transform.position = new UnityEngine.Vector3(__instance.sporeMask.transform.position.x, __instance.sporeMask.transform.position.y, 5f);
-    }
-}
-
-[HarmonyPatch(typeof(PlayerPhysics), nameof(PlayerPhysics.LateUpdate))]
-public static class SeeUserInfo_PlayerPhysics_LateUpdate_Postfix
-{
-    //Postfix patch of PlayerPhysics.LateUpdate to get user info
-    public static void Postfix(PlayerPhysics __instance)
-    {
-        if (CheatChecks.isLobby && CheatToggles.seeUserInfo)
-        {
-            string platform;
-            switch (AmongUsClient.Instance.GetClientFromCharacter(__instance.myPlayer).PlatformData.Platform)
-            {
-                case Platforms.StandaloneEpicPC:
-                    platform = "Epic Games - PC";
-                    break;
-                case Platforms.StandaloneSteamPC:
-                    platform = "Steam - PC";
-                    break;
-                case Platforms.StandaloneMac:
-                    platform = "Mac";
-                    break;
-                case Platforms.StandaloneWin10:
-                    platform = "Microsoft Store - PC";
-                    break;
-                case Platforms.StandaloneItch:
-                    platform = "itch.io - PC";
-                    break;
-                case Platforms.IPhone:
-                    platform = "iOS - Mobile";
-                    break;
-                case Platforms.Android:
-                    platform = "Android - Mobile";
-                    break;
-                case Platforms.Switch:
-                    platform = "Nintendo Switch - Console";
-                    break;
-                case Platforms.Xbox:
-                    platform = "Xbox - Console";
-                    break;
-                default:
-                    platform = "???";
-                    break;
-            }
-            var playerName = __instance.myPlayer.cosmetics.nameText.text;
-            playerName = "<size=50%>Level: <#0f0>" + (__instance.myPlayer.Data.PlayerLevel + 1) + "</color>\r\nPlatform: <#0f0>" + platform + "</color></size>\r\n" + playerName;
-            __instance.myPlayer.cosmetics.SetName(playerName);
-        }
     }
 }

--- a/src/ESP/EspCheatsPatches.cs
+++ b/src/ESP/EspCheatsPatches.cs
@@ -247,7 +247,7 @@ public static class SeeUserInfo_PlayerPhysics_LateUpdate_Postfix
                     break;
             }
             var playerName = __instance.myPlayer.cosmetics.nameText.text;
-            playerName = "<size=50%>Level: <#0f0>" + __instance.myPlayer.Data.PlayerLevel + "</color>\r\nPlatform: <#0f0>" + platform + "</color></size>\r\n" + playerName;
+            playerName = "<size=50%>Level: <#0f0>" + (__instance.myPlayer.Data.PlayerLevel + 1) + "</color>\r\nPlatform: <#0f0>" + platform + "</color></size>\r\n" + playerName;
             __instance.myPlayer.cosmetics.SetName(playerName);
         }
     }

--- a/src/MalumMenu.cs
+++ b/src/MalumMenu.cs
@@ -19,7 +19,7 @@ public partial class MalumMenu : BasePlugin
     private static MenuUI menuUI;
     public static ConfigEntry<string> menuKeybind;
     public static ConfigEntry<string> spoofFriendCode;
-    public static ConfigEntry<int> spoofLevel;
+    public static ConfigEntry<string> spoofLevel;
 
     public override void Load()
     {
@@ -37,8 +37,8 @@ public partial class MalumMenu : BasePlugin
 
         spoofLevel = Config.Bind("MalumMenu.Spoofing",
                                 "Level",
-                                100,
-                                "Your spoofed level that will be used in online games. IMPORTANT: spoofed level is not saved on servers");
+                                "",
+                                "Your spoofed level that will be used in online games.");
 
         Harmony.PatchAll();
         menuUI = AddComponent<MenuUI>();

--- a/src/MalumMenu.cs
+++ b/src/MalumMenu.cs
@@ -19,6 +19,7 @@ public partial class MalumMenu : BasePlugin
     private static MenuUI menuUI;
     public static ConfigEntry<string> menuKeybind;
     public static ConfigEntry<string> spoofFriendCode;
+    public static ConfigEntry<int> spoofLevel;
 
     public override void Load()
     {
@@ -33,7 +34,12 @@ public partial class MalumMenu : BasePlugin
                                 "FriendCode",
                                 "",
                                 "Your spoofed friend code that will be used in online games. IMPORTANT: When using a spoofed friend code, players won't be able to send you friend requests");
-        
+
+        spoofLevel = Config.Bind("MalumMenu.Spoofing",
+                                "Level",
+                                100,
+                                "Your spoofed level that will be used in online games. IMPORTANT: spoofed level is not saved on servers");
+
         Harmony.PatchAll();
         menuUI = AddComponent<MenuUI>();
 

--- a/src/Other/Utils.cs
+++ b/src/Other/Utils.cs
@@ -251,6 +251,11 @@ public static class Utils
         }
     }
 
+    public static string getRoleNameTranslated(RoleBehaviour role)
+    {
+        return DestroyableSingleton<TranslationController>.Instance.GetString(role.StringName, Array.Empty<Il2CppSystem.Object>());
+    }
+
     //Get the appropriate name color for a player depending on if cheat is enabled (cheatVar)
     public static string getNameTag(PlayerControl player, string playerName, bool isChat = false){
         string nameTag = playerName;
@@ -259,12 +264,12 @@ public static class Utils
 
             if (isChat){
                 
-                nameTag = $"<color=#{ColorUtility.ToHtmlStringRGB(player.Data.Role.TeamColor)}>{nameTag} <size=80%>({player.Data.Role.Role})</size></color>";
+                nameTag = $"<color=#{ColorUtility.ToHtmlStringRGB(player.Data.Role.TeamColor)}>{nameTag} <size=80%>({getRoleNameTranslated(player.Data.Role)})</size></color>";
 
                 return nameTag;
             }
 
-            nameTag = $"<color=#{ColorUtility.ToHtmlStringRGB(player.Data.Role.TeamColor)}><size=70%>{player.Data.Role.Role}</size>\r\n{nameTag}</color>";
+            nameTag = $"<color=#{ColorUtility.ToHtmlStringRGB(player.Data.Role.TeamColor)}><size=70%>{getRoleNameTranslated(player.Data.Role)}</size>\r\n{nameTag}</color>";
         
         }else if (PlayerControl.LocalPlayer.Data.Role.NameColor == player.Data.Role.NameColor){
 

--- a/src/Other/Utils.cs
+++ b/src/Other/Utils.cs
@@ -10,6 +10,7 @@ using System.Linq;
 using System.Reflection;
 using Il2CppSystem;
 using Sentry.Internal.Extensions;
+using AmongUs.GameOptions;
 
 namespace MalumMenu;
 public static class Utils
@@ -253,18 +254,50 @@ public static class Utils
         }
     }
 
-    public static string getRoleNameTranslated(RoleBehaviour role)
+    public static string getRoleNameTranslated(GameData.PlayerInfo playerData)
     {
-        return DestroyableSingleton<TranslationController>.Instance.GetString(role.StringName, Il2CppSystem.Array.Empty<Il2CppSystem.Object>());
+        var translatedRole = DestroyableSingleton<TranslationController>.Instance.GetString(playerData.Role.StringName, Il2CppSystem.Array.Empty<Il2CppSystem.Object>());
+        if (translatedRole == "STRMISS")
+        {
+            StringNames @string;
+            if (playerData.RoleWhenAlive.HasValue)
+            {
+                switch (playerData.RoleWhenAlive.Value)
+                {
+                    case RoleTypes.Crewmate:
+                        @string = DestroyableSingleton<CrewmateRole>.Instance.StringName;
+                        break;
+                    case RoleTypes.Engineer:
+                        @string = DestroyableSingleton<EngineerRole>.Instance.StringName;
+                        break;
+                    case RoleTypes.Scientist:
+                        @string = DestroyableSingleton<ScientistRole>.Instance.StringName;
+                        break;
+                    case RoleTypes.Impostor:
+                        @string = DestroyableSingleton<ImpostorRole>.Instance.StringName;
+                        break;
+                    case RoleTypes.Shapeshifter:
+                        @string = DestroyableSingleton<ShapeshifterRole>.Instance.StringName;
+                        break;
+                    default:
+                        @string = DestroyableSingleton<GuardianAngelRole>.Instance.StringName;
+                        break;
+                }
+                translatedRole = DestroyableSingleton<TranslationController>.Instance.GetString(@string, Il2CppSystem.Array.Empty<Il2CppSystem.Object>());
+            } else {
+                translatedRole = "Ghost";
+            }
+        }
+        return translatedRole;
     }
 
     //Get the appropriate name color for a player depending on if cheat is enabled (cheatVar)
     public static string getNameTag(PlayerControl player, string playerName, bool isChat = false){
         string nameTag = playerName;
 
-        if (CheatToggles.seeRoles){
+        if (CheatToggles.seeRoles && !IsInLobby()){
 
-            nameTag = $"<color=#{ColorUtility.ToHtmlStringRGB(player.Data.Role.TeamColor)}><size=70%><font=\"VCR SDF\" material=\"VCR Black Outline\">{getRoleNameTranslated(player.Data.Role)}</font></size>\r\n{nameTag}</color>";
+            nameTag = $"<color=#{ColorUtility.ToHtmlStringRGB(player.Data.Role.TeamColor)}><size=70%><font=\"VCR SDF\" material=\"VCR Black Outline\">{getRoleNameTranslated(player.Data)}</font></size>\r\n{nameTag}</color>";
         
         } else if (PlayerControl.LocalPlayer.Data.Role.NameColor == player.Data.Role.NameColor){
 

--- a/src/Other/Utils.cs
+++ b/src/Other/Utils.cs
@@ -254,7 +254,7 @@ public static class Utils
         }
     }
 
-    public static string getRoleNameTranslated(GameData.PlayerInfo playerData)
+    public static string getRoleName(GameData.PlayerInfo playerData)
     {
         var translatedRole = DestroyableSingleton<TranslationController>.Instance.GetString(playerData.Role.StringName, Il2CppSystem.Array.Empty<Il2CppSystem.Object>());
         if (translatedRole == "STRMISS")
@@ -295,9 +295,9 @@ public static class Utils
     public static string getNameTag(PlayerControl player, string playerName, bool isChat = false){
         string nameTag = playerName;
 
-        if (CheatToggles.seeRoles && !IsInLobby()){
+        if (CheatToggles.seeRoles){
 
-            nameTag = $"<color=#{ColorUtility.ToHtmlStringRGB(player.Data.Role.TeamColor)}><size=70%><font=\"VCR SDF\" material=\"VCR Black Outline\">{getRoleNameTranslated(player.Data)}</font></size>\r\n{nameTag}</color>";
+            nameTag = $"<color=#{ColorUtility.ToHtmlStringRGB(player.Data.Role.TeamColor)}><size=70%>{getRoleName(player.Data)}</size>\r\n{nameTag}</color>";
         
         } else if (PlayerControl.LocalPlayer.Data.Role.NameColor == player.Data.Role.NameColor){
 

--- a/src/Roles/ChangeRolePatch.cs
+++ b/src/Roles/ChangeRolePatch.cs
@@ -32,7 +32,7 @@ public static class ChangeRole_PlayerPhysics_LateUpdate_Postfix
                 shapeshifterChoice.Outfits[PlayerOutfitType.Default].SkinId = "skin_screamghostface";
                 shapeshifterChoice.Outfits[PlayerOutfitType.Default].VisorId = "visor_eliksni";
                 shapeshifterChoice.Role = RoleManager.Instance.AllRoles.First(r => r.Role == AmongUs.GameOptions.RoleTypes.Shapeshifter);
-                shapeshifterChoice.PlayerName = Utils.getRoleNameTranslated(shapeshifterChoice.Role);
+                shapeshifterChoice.PlayerName = Utils.getRoleNameTranslated(shapeshifterChoice);
                 playerDataList.Add(shapeshifterChoice);
 
                 GameData.PlayerInfo impostorChoice = new GameData.PlayerInfo(255)
@@ -41,7 +41,7 @@ public static class ChangeRole_PlayerPhysics_LateUpdate_Postfix
                 };
                 impostorChoice.Outfits[PlayerOutfitType.Default].ColorId = 0;
                 impostorChoice.Role = RoleManager.Instance.AllRoles.First(r => r.Role == AmongUs.GameOptions.RoleTypes.Impostor);
-                impostorChoice.PlayerName = Utils.getRoleNameTranslated(impostorChoice.Role);
+                impostorChoice.PlayerName = Utils.getRoleNameTranslated(impostorChoice);
                 playerDataList.Add(impostorChoice);
 
                 GameData.PlayerInfo engineerChoice = new GameData.PlayerInfo(255)
@@ -52,7 +52,7 @@ public static class ChangeRole_PlayerPhysics_LateUpdate_Postfix
                 engineerChoice.Outfits[PlayerOutfitType.Default].SkinId = "skin_Mech";
                 engineerChoice.Outfits[PlayerOutfitType.Default].VisorId = "visor_D2CGoggles";
                 engineerChoice.Role = RoleManager.Instance.AllRoles.First(r => r.Role == AmongUs.GameOptions.RoleTypes.Engineer);
-                engineerChoice.PlayerName = Utils.getRoleNameTranslated(engineerChoice.Role);
+                engineerChoice.PlayerName = Utils.getRoleNameTranslated(engineerChoice);
                 playerDataList.Add(engineerChoice);
 
                 GameData.PlayerInfo scientistChoice = new GameData.PlayerInfo(255)
@@ -63,7 +63,7 @@ public static class ChangeRole_PlayerPhysics_LateUpdate_Postfix
                 scientistChoice.Outfits[PlayerOutfitType.Default].SkinId = "skin_Science";
                 scientistChoice.Outfits[PlayerOutfitType.Default].VisorId = "visor_pk01_PaperMaskVisor";
                 scientistChoice.Role = RoleManager.Instance.AllRoles.First(r => r.Role == AmongUs.GameOptions.RoleTypes.Scientist);
-                scientistChoice.PlayerName = Utils.getRoleNameTranslated(scientistChoice.Role);
+                scientistChoice.PlayerName = Utils.getRoleNameTranslated(scientistChoice);
                 playerDataList.Add(scientistChoice);
 
                 GameData.PlayerInfo crewmateChoice = new GameData.PlayerInfo(255)
@@ -72,7 +72,7 @@ public static class ChangeRole_PlayerPhysics_LateUpdate_Postfix
                 };
                 crewmateChoice.Outfits[PlayerOutfitType.Default].ColorId = 10;
                 crewmateChoice.Role = RoleManager.Instance.AllRoles.First(r => r.Role == AmongUs.GameOptions.RoleTypes.Crewmate);
-                crewmateChoice.PlayerName = Utils.getRoleNameTranslated(crewmateChoice.Role);
+                crewmateChoice.PlayerName = Utils.getRoleNameTranslated(crewmateChoice);
                 playerDataList.Add(crewmateChoice);
 
                 //New player pick menu made for killing players

--- a/src/Roles/ChangeRolePatch.cs
+++ b/src/Roles/ChangeRolePatch.cs
@@ -32,7 +32,7 @@ public static class ChangeRole_PlayerPhysics_LateUpdate_Postfix
                 shapeshifterChoice.Outfits[PlayerOutfitType.Default].SkinId = "skin_screamghostface";
                 shapeshifterChoice.Outfits[PlayerOutfitType.Default].VisorId = "visor_eliksni";
                 shapeshifterChoice.Role = RoleManager.Instance.AllRoles.First(r => r.Role == AmongUs.GameOptions.RoleTypes.Shapeshifter);
-                shapeshifterChoice.PlayerName = Utils.getRoleNameTranslated(shapeshifterChoice);
+                shapeshifterChoice.PlayerName = Utils.getRoleName(shapeshifterChoice);
                 playerDataList.Add(shapeshifterChoice);
 
                 GameData.PlayerInfo impostorChoice = new GameData.PlayerInfo(255)
@@ -41,7 +41,7 @@ public static class ChangeRole_PlayerPhysics_LateUpdate_Postfix
                 };
                 impostorChoice.Outfits[PlayerOutfitType.Default].ColorId = 0;
                 impostorChoice.Role = RoleManager.Instance.AllRoles.First(r => r.Role == AmongUs.GameOptions.RoleTypes.Impostor);
-                impostorChoice.PlayerName = Utils.getRoleNameTranslated(impostorChoice);
+                impostorChoice.PlayerName = Utils.getRoleName(impostorChoice);
                 playerDataList.Add(impostorChoice);
 
                 GameData.PlayerInfo engineerChoice = new GameData.PlayerInfo(255)
@@ -52,7 +52,7 @@ public static class ChangeRole_PlayerPhysics_LateUpdate_Postfix
                 engineerChoice.Outfits[PlayerOutfitType.Default].SkinId = "skin_Mech";
                 engineerChoice.Outfits[PlayerOutfitType.Default].VisorId = "visor_D2CGoggles";
                 engineerChoice.Role = RoleManager.Instance.AllRoles.First(r => r.Role == AmongUs.GameOptions.RoleTypes.Engineer);
-                engineerChoice.PlayerName = Utils.getRoleNameTranslated(engineerChoice);
+                engineerChoice.PlayerName = Utils.getRoleName(engineerChoice);
                 playerDataList.Add(engineerChoice);
 
                 GameData.PlayerInfo scientistChoice = new GameData.PlayerInfo(255)
@@ -63,7 +63,7 @@ public static class ChangeRole_PlayerPhysics_LateUpdate_Postfix
                 scientistChoice.Outfits[PlayerOutfitType.Default].SkinId = "skin_Science";
                 scientistChoice.Outfits[PlayerOutfitType.Default].VisorId = "visor_pk01_PaperMaskVisor";
                 scientistChoice.Role = RoleManager.Instance.AllRoles.First(r => r.Role == AmongUs.GameOptions.RoleTypes.Scientist);
-                scientistChoice.PlayerName = Utils.getRoleNameTranslated(scientistChoice);
+                scientistChoice.PlayerName = Utils.getRoleName(scientistChoice);
                 playerDataList.Add(scientistChoice);
 
                 GameData.PlayerInfo crewmateChoice = new GameData.PlayerInfo(255)
@@ -72,7 +72,7 @@ public static class ChangeRole_PlayerPhysics_LateUpdate_Postfix
                 };
                 crewmateChoice.Outfits[PlayerOutfitType.Default].ColorId = 10;
                 crewmateChoice.Role = RoleManager.Instance.AllRoles.First(r => r.Role == AmongUs.GameOptions.RoleTypes.Crewmate);
-                crewmateChoice.PlayerName = Utils.getRoleNameTranslated(crewmateChoice);
+                crewmateChoice.PlayerName = Utils.getRoleName(crewmateChoice);
                 playerDataList.Add(crewmateChoice);
 
                 //New player pick menu made for killing players

--- a/src/Roles/ChangeRolePatch.cs
+++ b/src/Roles/ChangeRolePatch.cs
@@ -32,6 +32,7 @@ public static class ChangeRole_PlayerPhysics_LateUpdate_Postfix
                 shapeshifterChoice.Outfits[PlayerOutfitType.Default].SkinId = "skin_screamghostface";
                 shapeshifterChoice.Outfits[PlayerOutfitType.Default].VisorId = "visor_eliksni";
                 shapeshifterChoice.Role = RoleManager.Instance.AllRoles.First(r => r.Role == AmongUs.GameOptions.RoleTypes.Shapeshifter);
+                shapeshifterChoice.PlayerName = Utils.getRoleNameTranslated(shapeshifterChoice.Role);
                 playerDataList.Add(shapeshifterChoice);
 
                 GameData.PlayerInfo impostorChoice = new GameData.PlayerInfo(255)
@@ -40,6 +41,7 @@ public static class ChangeRole_PlayerPhysics_LateUpdate_Postfix
                 };
                 impostorChoice.Outfits[PlayerOutfitType.Default].ColorId = 0;
                 impostorChoice.Role = RoleManager.Instance.AllRoles.First(r => r.Role == AmongUs.GameOptions.RoleTypes.Impostor);
+                impostorChoice.PlayerName = Utils.getRoleNameTranslated(impostorChoice.Role);
                 playerDataList.Add(impostorChoice);
 
                 GameData.PlayerInfo engineerChoice = new GameData.PlayerInfo(255)
@@ -50,6 +52,7 @@ public static class ChangeRole_PlayerPhysics_LateUpdate_Postfix
                 engineerChoice.Outfits[PlayerOutfitType.Default].SkinId = "skin_Mech";
                 engineerChoice.Outfits[PlayerOutfitType.Default].VisorId = "visor_D2CGoggles";
                 engineerChoice.Role = RoleManager.Instance.AllRoles.First(r => r.Role == AmongUs.GameOptions.RoleTypes.Engineer);
+                engineerChoice.PlayerName = Utils.getRoleNameTranslated(engineerChoice.Role);
                 playerDataList.Add(engineerChoice);
 
                 GameData.PlayerInfo scientistChoice = new GameData.PlayerInfo(255)
@@ -60,6 +63,7 @@ public static class ChangeRole_PlayerPhysics_LateUpdate_Postfix
                 scientistChoice.Outfits[PlayerOutfitType.Default].SkinId = "skin_Science";
                 scientistChoice.Outfits[PlayerOutfitType.Default].VisorId = "visor_pk01_PaperMaskVisor";
                 scientistChoice.Role = RoleManager.Instance.AllRoles.First(r => r.Role == AmongUs.GameOptions.RoleTypes.Scientist);
+                scientistChoice.PlayerName = Utils.getRoleNameTranslated(scientistChoice.Role);
                 playerDataList.Add(scientistChoice);
 
                 GameData.PlayerInfo crewmateChoice = new GameData.PlayerInfo(255)
@@ -68,6 +72,7 @@ public static class ChangeRole_PlayerPhysics_LateUpdate_Postfix
                 };
                 crewmateChoice.Outfits[PlayerOutfitType.Default].ColorId = 10;
                 crewmateChoice.Role = RoleManager.Instance.AllRoles.First(r => r.Role == AmongUs.GameOptions.RoleTypes.Crewmate);
+                crewmateChoice.PlayerName = Utils.getRoleNameTranslated(crewmateChoice.Role);
                 playerDataList.Add(crewmateChoice);
 
                 //New player pick menu made for killing players

--- a/src/Roles/Impostor/ImpostorCheatsPatches.cs
+++ b/src/Roles/Impostor/ImpostorCheatsPatches.cs
@@ -2,6 +2,9 @@ using System.Linq;
 using HarmonyLib;
 using System.Collections.Generic;
 using UnityEngine;
+using System;
+using System.Text;
+using AmongUs.GameOptions;
 
 namespace MalumMenu;
 
@@ -107,13 +110,12 @@ public static class killJailbreak_ImpostorRole_IsValidTarget_Postfix
     }
 }
 
-[HarmonyPatch(typeof(Console), nameof(Console.CanUse))]
+[HarmonyPatch(typeof(ImpostorRole), nameof(ImpostorRole.CanUse))]
 public static class impostorTasks_ImpostorRole_CanUse_Prefix
 {
-    //Prefix patch of Console.CanUse to do tasks as an impostor
-    public static bool Prefix(Console __instance)
+    //Prefix patch of ImpostorRole.CanUse to do tasks as an impostor
+    public static void Postfix(ImpostorRole __instance, Console usable, ref bool __result)
     {
-        __instance.AllowImpostor = CheatToggles.impostorTasks;
-        return true;
+        __result = !(usable != null) || usable.AllowImpostor || CheatToggles.impostorTasks;
     }
 }

--- a/src/Ship/SabotageCheatsPatches.cs
+++ b/src/Ship/SabotageCheatsPatches.cs
@@ -1,5 +1,6 @@
 using HarmonyLib;
 using System;
+using System.Runtime.CompilerServices;
 
 namespace MalumMenu;
 
@@ -11,137 +12,64 @@ public static class Sabotages_ShipStatus_FixedUpdate_Postfix
     {
         byte currentMapID = Utils.getCurrentMapID();
 
-        if (CheatToggles.reactorSab){ //Reactor sabotages
+        if (CheatToggles.reactorSab && !BetterSabotage_ShipStatus_UpdateSystem_Postfix.reactorSab) { //Reactor sabotages
 
-            if (currentMapID == 2){ //Polus uses has SystemTypes.Laboratory instead of SystemTypes.Reactor
+            if (currentMapID == 2) { //Polus uses has SystemTypes.Laboratory instead of SystemTypes.Reactor
                 
-                var labSystem = __instance.Systems[SystemTypes.Laboratory].Cast<ReactorSystemType>();
-                
-                if (labSystem.IsActive){
+                __instance.RpcUpdateSystem(SystemTypes.Laboratory, 128);
 
-                    __instance.RpcUpdateSystem(SystemTypes.Laboratory, 16); //Repair reactor
-                
-                }else{
-                    
-                    __instance.RpcUpdateSystem(SystemTypes.Laboratory, 128); //Sabotage reactor
-                
-                }
+            } else if (currentMapID == 4) { //Airship uses HeliSabotageSystem to sabotage reactor
 
-            }else if (currentMapID == 4){ //Airship uses HeliSabotageSystem to sabotage reactor
+                __instance.RpcUpdateSystem(SystemTypes.HeliSabotage, 128);
 
-                var HeliSystem = __instance.Systems[SystemTypes.HeliSabotage].Cast<HeliSabotageSystem>();
-                
-                if (HeliSystem.IsActive){
-                    
-                    //Repair reactor
-                    __instance.RpcUpdateSystem(SystemTypes.HeliSabotage, 16 | 0);
-                    __instance.RpcUpdateSystem(SystemTypes.HeliSabotage, 16 | 1);
-
-                }else{
-
-                    //Sabotage reactor
-                    __instance.RpcUpdateSystem(SystemTypes.HeliSabotage, 128);
-
-                }
-
-            }else{ //Other maps behave normally 
-                var reactSystem = __instance.Systems[SystemTypes.Reactor].Cast<ReactorSystemType>();
-                if (reactSystem.IsActive){
-                    __instance.RpcUpdateSystem(SystemTypes.Reactor, 16);
-                }else{
-                    __instance.RpcUpdateSystem(SystemTypes.Reactor, 128);
-                }
+            } else { //Other maps behave normally 
+                __instance.RpcUpdateSystem(SystemTypes.Reactor, 128);
             }
 
-            CheatToggles.reactorSab = false; //Button behaviour
+        } else if (CheatToggles.oxygenSab && !BetterSabotage_ShipStatus_UpdateSystem_Postfix.oxygenSab) { //Oxygen sabotages
 
-        }else if (CheatToggles.oxygenSab){ //Oxygen sabotages
+            if (currentMapID != 4 && currentMapID != 2 && currentMapID != 5) { //Polus, Airship & Fungle have NO oxygen system
 
-            if (currentMapID != 4 && currentMapID != 2 && currentMapID != 5){ //Polus, Airship & Fungle have NO oxygen system
+                __instance.RpcUpdateSystem(SystemTypes.LifeSupp, 128);
 
-                var oxygenSystem = __instance.Systems[SystemTypes.LifeSupp].Cast<LifeSuppSystemType>();
-                
-                if (oxygenSystem.IsActive){
-                    __instance.RpcUpdateSystem(SystemTypes.LifeSupp, 16); //Repair oxygen
-                }else{
-                    __instance.RpcUpdateSystem(SystemTypes.LifeSupp, 128); //Sabotage oxygen
-                }
-
-            }else{
+            } else {
                 HudManager.Instance.Notifier.AddItem("Oxygen system not present on this map");
             }
-
-            CheatToggles.oxygenSab = false; //Button behaviour
         
-        }else if (CheatToggles.commsSab){ //Communications sabotages
-            
-            if (currentMapID == 1 || currentMapID == 5){ //MiraHQ and Fungle use HqHudSystemType to sabotage communications
-                var hqcommsSystem = __instance.Systems[SystemTypes.Comms].Cast<HqHudSystemType>();
-                if (hqcommsSystem.IsActive){
-                    __instance.RpcUpdateSystem(SystemTypes.Comms, 16 | 0); //Repair communications
-                    __instance.RpcUpdateSystem(SystemTypes.Comms, 16 | 1);
-                }else{
-                    __instance.RpcUpdateSystem(SystemTypes.Comms, 128); //Sabotage communications
-                }
-            }else{//Polus, Skeld and Airship have normal behaviour
-                var commsSystem = __instance.Systems[SystemTypes.Comms].Cast<HudOverrideSystemType>();
-                if (commsSystem.IsActive){
-                    __instance.RpcUpdateSystem(SystemTypes.Comms, 16); //Repair communications
-                }else{
-                    __instance.RpcUpdateSystem(SystemTypes.Comms, 128); //Sabotage communications
-                }
-            }
+        } else if (CheatToggles.commsSab && !BetterSabotage_ShipStatus_UpdateSystem_Postfix.commsSab) { //Communications sabotages
 
-            CheatToggles.commsSab = false; //Button behaviour
+            __instance.RpcUpdateSystem(SystemTypes.Comms, 128);
 
-        }else if (CheatToggles.elecSab){ //Eletrical sabotage
+        } else if (CheatToggles.elecSab && !BetterSabotage_ShipStatus_UpdateSystem_Postfix.elecSab) { //Eletrical sabotage
 
-            if (currentMapID != 5){ //Fungle has no eletrical sabotage
+            if (currentMapID != 5) { //Fungle has no eletrical sabotage
 
-                var elecSystem = __instance.Systems[SystemTypes.Electrical].Cast<SwitchSystem>();
-
-                if (elecSystem.ActualSwitches != elecSystem.ExpectedSwitches){
-                    
-                    for (var i = 0; i < 5; i++) {
-                        var switchMask = 1 << (i & 0x1F);
-
-                        if ((elecSystem.ActualSwitches & switchMask) != (elecSystem.ExpectedSwitches & switchMask)){
-                            __instance.RpcUpdateSystem(SystemTypes.Electrical, (byte)i); //Repair electrical
-                        }
-                    }    
-
-                }else{
-
-                    byte b = 4;
-                    for (int i = 0; i < 5; i++)
+                byte b = 4;
+                for (int i = 0; i < 5; i++)
+                {
+                    if (BoolRange.Next(0.5f))
                     {
-                        if (BoolRange.Next(0.5f))
-                        {
-                            b |= (byte)(1 << i);
-                        }
+                        b |= (byte)(1 << i);
                     }
-
-                    __instance.RpcUpdateSystem(SystemTypes.Electrical, (byte)(b | 128)); //Sabotage electrical
-
                 }
 
-            }else{
+                __instance.RpcUpdateSystem(SystemTypes.Electrical, (byte)(b | 128));
+
+            } else {
                 HudManager.Instance.Notifier.AddItem("Eletrical system not present on this map");
             }
-
-            CheatToggles.elecSab = false; //Button behaviour
             
-        }else if (CheatToggles.mushSab){
+        } else if (CheatToggles.mushSab) {
 
             if (currentMapID == 5){ //MushroomMixup only works on Fungle
                 __instance.RpcUpdateSystem(SystemTypes.MushroomMixupSabotage, 1); //Sabotage MushroomMixup
-            }else{
+            } else {
                 HudManager.Instance.Notifier.AddItem("Mushrooms not present on this map");
             }
 
             CheatToggles.mushSab = false; //Button behaviour
 
-        }else if (CheatToggles.doorsSab){
+        } else if (CheatToggles.doorsSab) {
 
             //Loop through all rooms and close their doors
             foreach (SystemTypes room in (SystemTypes[]) Enum.GetValues(typeof(SystemTypes)))
@@ -150,6 +78,81 @@ public static class Sabotages_ShipStatus_FixedUpdate_Postfix
             }
 
             CheatToggles.doorsSab = false; //Button behaviour
+
+        }
+
+
+        // repair sabotage
+        if (!CheatToggles.reactorSab && BetterSabotage_ShipStatus_UpdateSystem_Postfix.reactorSab)
+        {
+            if (currentMapID == 2)
+            {
+                __instance.RpcUpdateSystem(SystemTypes.Laboratory, 16);
+            }
+            else if (currentMapID == 4)
+            {
+
+                __instance.RpcUpdateSystem(SystemTypes.HeliSabotage, 16 | 0);
+                __instance.RpcUpdateSystem(SystemTypes.HeliSabotage, 16 | 1);
+
+            }
+            else
+            {
+                __instance.RpcUpdateSystem(SystemTypes.Reactor, 16);
+            }
+
+            BetterSabotage_ShipStatus_UpdateSystem_Postfix.reactorSab = false;
+
+        }
+        else if (!CheatToggles.oxygenSab && BetterSabotage_ShipStatus_UpdateSystem_Postfix.oxygenSab)
+        {
+
+            if (currentMapID != 4 && currentMapID != 2 && currentMapID != 5)
+            {
+
+                __instance.RpcUpdateSystem(SystemTypes.LifeSupp, 16);
+
+            }
+
+            BetterSabotage_ShipStatus_UpdateSystem_Postfix.oxygenSab = false;
+
+        }
+        else if (!CheatToggles.commsSab && BetterSabotage_ShipStatus_UpdateSystem_Postfix.commsSab)
+        {
+
+            if (currentMapID == 1 || currentMapID == 5)
+            {
+                __instance.RpcUpdateSystem(SystemTypes.Comms, 16 | 0);
+                __instance.RpcUpdateSystem(SystemTypes.Comms, 16 | 1);
+            }
+            else
+            {
+                __instance.RpcUpdateSystem(SystemTypes.Comms, 16);
+            }
+
+            BetterSabotage_ShipStatus_UpdateSystem_Postfix.commsSab = false;
+
+        }
+        else if (!CheatToggles.elecSab && BetterSabotage_ShipStatus_UpdateSystem_Postfix.elecSab)
+        {
+
+            if (currentMapID != 5)
+            {
+                var elecSystem = __instance.Systems[SystemTypes.Electrical].Cast<SwitchSystem>();
+
+                for (var i = 0; i < 5; i++)
+                {
+                    var switchMask = 1 << (i & 0x1F);
+
+                    if ((elecSystem.ActualSwitches & switchMask) != (elecSystem.ExpectedSwitches & switchMask))
+                    {
+                        __instance.RpcUpdateSystem(SystemTypes.Electrical, (byte)i);
+                    }
+                }
+
+            }
+
+            BetterSabotage_ShipStatus_UpdateSystem_Postfix.elecSab = false;
 
         }
     }
@@ -182,5 +185,38 @@ public static class UnfixableLights_ShipStatus_FixedUpdate_Postfix
 
             CheatToggles.unfixableLights = false;
         } 
+    }
+}
+
+[HarmonyPatch(typeof(ShipStatus), nameof(ShipStatus.UpdateSystem))]
+[HarmonyPatch(new Type[] { typeof(SystemTypes), typeof(PlayerControl), typeof(byte) })]
+public static class BetterSabotage_ShipStatus_UpdateSystem_Postfix
+{
+    public static bool reactorSab;
+    public static bool oxygenSab;
+    public static bool commsSab;
+    public static bool elecSab;
+    public static void Postfix(SystemTypes systemType, PlayerControl player, byte amount, ShipStatus __instance)
+    {
+        if ((systemType == SystemTypes.HeliSabotage || systemType == SystemTypes.Laboratory || systemType == SystemTypes.Reactor) && amount == 128)
+        {
+            CheatToggles.reactorSab = true;
+            reactorSab = true;
+        }
+        else if (systemType == SystemTypes.LifeSupp && amount == 128)
+        {
+            CheatToggles.oxygenSab = true;
+            oxygenSab = true;
+        }
+        else if (systemType == SystemTypes.Comms && amount == 128)
+        {
+            CheatToggles.commsSab = true;
+            commsSab = true;
+        }
+        else if (systemType == SystemTypes.Electrical && amount.HasBit(128))
+        {
+            CheatToggles.elecSab = true;
+            elecSab = true;
+        }
     }
 }

--- a/src/Ship/SabotageCheatsPatches.cs
+++ b/src/Ship/SabotageCheatsPatches.cs
@@ -207,19 +207,19 @@ public static class Sabotages_ShipStatus_FixedUpdate_Postfix
                 break;
         }
 
-        if (!reactorSab && (reactorSys != null || labSys != null || HeliSys != null))
+        if (reactorSys != null || labSys != null || HeliSys != null)
         {
             var reactorSabctive = reactorSys == null ? labSys == null ? HeliSys.IsActive : labSys.IsActive : reactorSys.IsActive;
             CheatToggles.reactorSab = reactorSabctive;
             reactorSab = reactorSabctive;
         }
-        if (!commsSab && ((hqcommsSys != null && hqcommsSys.IsActive) || (commsSys != null && commsSys.IsActive)))
+        if ((hqcommsSys != null && hqcommsSys.IsActive) || (commsSys != null && commsSys.IsActive))
         {
             var commsSabActive = hqcommsSys == null ? commsSys.IsActive : hqcommsSys.IsActive;
             CheatToggles.commsSab = commsSabActive;
             commsSab = commsSabActive;
         }
-        if (!oxygenSab && oxygenSys != null)
+        if (oxygenSys != null)
         {
             CheatToggles.oxygenSab = oxygenSys.IsActive;
             oxygenSab = oxygenSys.IsActive;

--- a/src/Spoofing/SpoofingCheatsPatch.cs
+++ b/src/Spoofing/SpoofingCheatsPatch.cs
@@ -1,11 +1,15 @@
+using AmongUs.Data;
+using AmongUs.Data.Player;
 using HarmonyLib;
+using static Il2CppSystem.Linq.Expressions.Interpreter.CastInstruction.CastInstructionNoT;
 
 namespace MalumMenu;
 
 [HarmonyPatch(typeof(EOSManager), nameof(EOSManager.Update))]
-public static class SpoofFriendCode_EOSManager_Update_Postfix
+public static class Spoofing_EOSManager_Update_Postfix
 {
     public static string defaultFC = null;
+    public static int defaultLevel = -1;
 
     //Postfix patch of EOSManager.Update to spoof friend codes
     public static void Postfix(EOSManager __instance)
@@ -20,21 +24,34 @@ public static class SpoofFriendCode_EOSManager_Update_Postfix
                 string username = DestroyableSingleton<AccountManager>.Instance.GetRandomName().ToLower();
                 string discriminator = new System.Random().Next(1000, 10000).ToString();
                 __instance.FriendCode = username + "#" + discriminator;
-
-                return; //Do not use friend code spoofing from config if spoofRandomFC cheat is already going on
             }
 
-            if (MalumMenu.spoofFriendCode.Value != "" && MalumMenu.spoofFriendCode.Value != __instance.FriendCode){ //friendCodeSpoofing from config cheat logic
+            else if (MalumMenu.spoofFriendCode.Value != "" && MalumMenu.spoofFriendCode.Value != __instance.FriendCode){ //friendCodeSpoofing from config cheat logic
                 __instance.FriendCode = MalumMenu.spoofFriendCode.Value; //Set custom friend code from config file
-                
-                return;
             }
 
             //Return to default friend code if both cheats are disabled
-            if (defaultFC != null){
+            else if (defaultFC != null){
                 __instance.FriendCode = defaultFC;
                 defaultFC = null;
             }
-        }catch{}
+
+            if (CheatToggles.spoofLevel && MalumMenu.spoofLevel.Value.ToString() != "" && MalumMenu.spoofLevel.Value > 0)
+            {
+                if (defaultLevel == -1)
+                {
+                    defaultLevel = (int)DataManager.Player.Stats.Level;
+                }
+                DataManager.Player.stats.level = (uint)MalumMenu.spoofLevel.Value - 1;
+                DataManager.Player.Save();
+            }
+            else if (defaultLevel > 0)
+            {
+                DataManager.Player.stats.level = (uint)defaultLevel;
+                DataManager.Player.Save();
+                defaultLevel = -1;
+            }
+        }
+        catch{}
     }
 }

--- a/src/Spoofing/SpoofingCheatsPatch.cs
+++ b/src/Spoofing/SpoofingCheatsPatch.cs
@@ -9,7 +9,7 @@ namespace MalumMenu;
 public static class Spoofing_EOSManager_Update_Postfix
 {
     public static string defaultFC = null;
-    public static int defaultLevel = -1;
+    public static string defaultLevel = null;
 
     //Postfix patch of EOSManager.Update to spoof friend codes
     public static void Postfix(EOSManager __instance)
@@ -36,20 +36,20 @@ public static class Spoofing_EOSManager_Update_Postfix
                 defaultFC = null;
             }
 
-            if (CheatToggles.spoofLevel && MalumMenu.spoofLevel.Value.ToString() != "" && MalumMenu.spoofLevel.Value > 0)
-            {
-                if (defaultLevel == -1)
+            if (MalumMenu.spoofLevel.Value != "" && int.Parse(MalumMenu.spoofLevel.Value) > 0 && int.Parse(MalumMenu.spoofLevel.Value) != (int)DataManager.Player.Stats.Level){ //friendCodeSpoofing from config cheat logic
+                if (defaultLevel == null)
                 {
-                    defaultLevel = (int)DataManager.Player.Stats.Level;
+                    defaultLevel = $"{DataManager.Player.Stats.Level}";
                 }
-                DataManager.Player.stats.level = (uint)MalumMenu.spoofLevel.Value - 1;
+
+                DataManager.Player.stats.level = (uint)(int.Parse(MalumMenu.spoofLevel.Value) - 1);
                 DataManager.Player.Save();
             }
-            else if (defaultLevel > 0)
-            {
-                DataManager.Player.stats.level = (uint)defaultLevel;
+
+            else if (defaultLevel != null){
+                DataManager.Player.stats.level = (uint)int.Parse(defaultLevel);
                 DataManager.Player.Save();
-                defaultLevel = -1;
+                defaultLevel = null;
             }
         }
         catch{}

--- a/src/UI/CheatToggles.cs
+++ b/src/UI/CheatToggles.cs
@@ -60,6 +60,7 @@ namespace MalumMenu
         //Spoofing
         public static bool spoofRandomFC;
         public static bool copyPlayerFC;
+        public static bool spoofLevel;
 
         //Camera
         public static bool spectate;

--- a/src/UI/CheatToggles.cs
+++ b/src/UI/CheatToggles.cs
@@ -29,6 +29,7 @@ namespace MalumMenu
         public static bool seeDisguises;
         public static bool seeGhosts;
         public static bool seeRoles;
+        public static bool seeUserInfo;
         public static bool ventVision;
         public static bool revealVotes;
 

--- a/src/UI/CheatToggles.cs
+++ b/src/UI/CheatToggles.cs
@@ -29,7 +29,6 @@ namespace MalumMenu
         public static bool seeDisguises;
         public static bool seeGhosts;
         public static bool seeRoles;
-        public static bool seeUserInfo;
         public static bool ventVision;
         public static bool revealVotes;
 
@@ -60,7 +59,6 @@ namespace MalumMenu
         //Spoofing
         public static bool spoofRandomFC;
         public static bool copyPlayerFC;
-        public static bool spoofLevel;
 
         //Camera
         public static bool spectate;

--- a/src/UI/MenuUI.cs
+++ b/src/UI/MenuUI.cs
@@ -196,7 +196,8 @@ public class MenuUI : MonoBehaviour
 
         //Some cheats only work if the ship is present, so they are turned off if it is not
         if(!CheatChecks.isShip){
-            CheatToggles.unfixableLights = CheatToggles.completeAllTasks = CheatToggles.completeMyTasks = CheatToggles.kickVents = CheatToggles.reportBody = CheatToggles.closeMeeting = CheatToggles.reactorSab = CheatToggles.oxygenSab = CheatToggles.commsSab = CheatToggles.mushSab = CheatToggles.doorsSab = false;
+            CheatToggles.unfixableLights = CheatToggles.completeAllTasks = CheatToggles.completeMyTasks = CheatToggles.kickVents = CheatToggles.reportBody = CheatToggles.closeMeeting = CheatToggles.reactorSab = CheatToggles.oxygenSab = CheatToggles.commsSab = CheatToggles.elecSab = CheatToggles.mushSab = CheatToggles.doorsSab = false;
+            Sabotages_ShipStatus_FixedUpdate_Postfix.reactorSab = Sabotages_ShipStatus_FixedUpdate_Postfix.commsSab = Sabotages_ShipStatus_FixedUpdate_Postfix.elecSab = Sabotages_ShipStatus_FixedUpdate_Postfix.oxygenSab = UnfixableLights_ShipStatus_FixedUpdate_Postfix.isActive = false;
         }
     }
 

--- a/src/UI/MenuUI.cs
+++ b/src/UI/MenuUI.cs
@@ -24,7 +24,7 @@ public class MenuUI : MonoBehaviour
             new ToggleInfo(" SeeGhosts", () => CheatToggles.seeGhosts, x => CheatToggles.seeGhosts = x),
             new ToggleInfo(" FullBright", () => CheatToggles.fullBright, x => CheatToggles.fullBright = x),
             new ToggleInfo(" RevealVotes", () => CheatToggles.revealVotes, x => CheatToggles.revealVotes = x),
-
+            new ToggleInfo(" SeeUserInfo", () => CheatToggles.seeUserInfo, x => CheatToggles.seeUserInfo = x),
         }, new List<SubmenuInfo> {
             new SubmenuInfo("NameTags", false, new List<ToggleInfo>() {
                 new ToggleInfo(" SeeRoles", () => CheatToggles.seeRoles, x => CheatToggles.seeRoles = x),

--- a/src/UI/MenuUI.cs
+++ b/src/UI/MenuUI.cs
@@ -85,7 +85,7 @@ public class MenuUI : MonoBehaviour
                 }),
                 new SubmenuInfo("Impostor", false, new List<ToggleInfo>() {
                     new ToggleInfo(" KillAnyone", () => CheatToggles.killAnyone, x => CheatToggles.killAnyone = x),
-                    new ToggleInfo(" NoKillCd", () => CheatToggles.zeroKillCd, x => CheatToggles.zeroKillCd = x),
+                    new ToggleInfo(" NoKillCooldown", () => CheatToggles.zeroKillCd, x => CheatToggles.zeroKillCd = x),
                     new ToggleInfo(" KillReach", () => CheatToggles.killReach, x => CheatToggles.killReach = x),
                     new ToggleInfo(" ImpostorTasks", () => CheatToggles.impostorTasks, x => CheatToggles.impostorTasks = x),
                 }),

--- a/src/UI/MenuUI.cs
+++ b/src/UI/MenuUI.cs
@@ -161,6 +161,7 @@ public class MenuUI : MonoBehaviour
             }),
             new SubmenuInfo("Config", false, new List<ToggleInfo>() {
                 new ToggleInfo(" Spoofed FriendCode", () => MalumMenu.spoofFriendCode.Value != "", (bool n) => { }),
+                new ToggleInfo($" Spoof Level: {MalumMenu.spoofLevel.Value}", () => CheatToggles.spoofLevel, x => CheatToggles.spoofLevel = x),
             }),
         }));
 

--- a/src/UI/MenuUI.cs
+++ b/src/UI/MenuUI.cs
@@ -24,7 +24,6 @@ public class MenuUI : MonoBehaviour
             new ToggleInfo(" SeeGhosts", () => CheatToggles.seeGhosts, x => CheatToggles.seeGhosts = x),
             new ToggleInfo(" FullBright", () => CheatToggles.fullBright, x => CheatToggles.fullBright = x),
             new ToggleInfo(" RevealVotes", () => CheatToggles.revealVotes, x => CheatToggles.revealVotes = x),
-            new ToggleInfo(" SeeUserInfo", () => CheatToggles.seeUserInfo, x => CheatToggles.seeUserInfo = x),
         }, new List<SubmenuInfo> {
             new SubmenuInfo("NameTags", false, new List<ToggleInfo>() {
                 new ToggleInfo(" SeeRoles", () => CheatToggles.seeRoles, x => CheatToggles.seeRoles = x),
@@ -161,7 +160,7 @@ public class MenuUI : MonoBehaviour
             }),
             new SubmenuInfo("Config", false, new List<ToggleInfo>() {
                 new ToggleInfo(" Spoofed FriendCode", () => MalumMenu.spoofFriendCode.Value != "", (bool n) => { }),
-                new ToggleInfo($" Spoof Level: {MalumMenu.spoofLevel.Value}", () => CheatToggles.spoofLevel, x => CheatToggles.spoofLevel = x),
+                new ToggleInfo(" Spoofed Level", () => MalumMenu.spoofLevel.Value != "", (bool n) => { }),
             }),
         }));
 


### PR DESCRIPTION
> Better sabotage system is basically this:
> 
> Instead of having sabotages be buttons that enable/disable a sabotage, they should be controllable toggles that indicate the current status of the sabotage
> For example, if the impostor induces reactor sabotage, it should get automatically toggled on in the menu. then, if the malum user manually toggles it off, the rpc to disable it is sent automatically
> or if the malum user toggles on reactor sabotage and it gets fixed by the players, it should automatically toggle off in the menu to show that it is no longer happening 
> basically you should be able to see & control the status of all the sabotages from the malummenu ui
> I think this would make it much clearer to control sabotages 
> (btw unfixablelights should be included too in this cheat, and since it works differently to the normal lights sabotage it should be handled separately)


Since your and my comment styles are different, please leave your own comments, scp :)