### PR TITLE
Adding a revive system to MalumMenu

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,20 +3,6 @@
   <img src="https://scp222thj.dev/static/images/malumLogo.png">
 </p>
 
-
-<p align="center">
-  
-  <a href="https://discord.gg/YYcYf88jAb">
-    <img src="https://img.shields.io/badge/Join%20us%20on-Discord-blue?style=flat&logo=discord" alt="Discord">
-  </a>
-  
-  <a href="https://ko-fi.com/scp222thj">
-    <img src="https://img.shields.io/badge/Support%20me%20on-Ko--fi-ff5f5f?style=flat&logo=ko-fi" alt="Ko-fi">
-  </a>
-  
-</p>
-
-<p align="center">
 <b>An easy-to-use Among Us cheat menu with a simple GUI and lots of useful modules. </b>
 Note: this is an unofficial rework of the MaluMenu mod with everything I wanted to add and which were refused, check the official one here: https://github.com/scp222thj/MalumMenu
 

--- a/README.md
+++ b/README.md
@@ -18,7 +18,7 @@
 
 <p align="center">
 <b>An easy-to-use Among Us cheat menu with a simple GUI and lots of useful modules. </b>
-
+Note: this is an unofficial rework of the MaluMenu mod with everything I wanted to add and which were refused, check the official one here: https://github.com/scp222thj/MalumMenu
 
 # 😎 Table Of Contents
 - [🎁 Releases](#-releases)
@@ -30,15 +30,7 @@
 # 🎁 Releases
 | Mod Version| Among Us - Version | Link |
 |----------|-------------|-----------------|
-| v2.2.0 | 2024.3.5 | [Download](https://github.com/scp222thj/MalumMenu/releases/download/v2.2.0/MalumMenu-2.2.0.zip) |
-| v2.1.0 | 2023.11.28 | [Download](https://github.com/scp222thj/MalumMenu/releases/download/v2.1.0/MalumMenu-2.1.0.zip) |
-| v2.0.0 | 2023.11.28 | [Download](https://github.com/scp222thj/MalumMenu/releases/download/v2.0.0/MalumMenu-2.0.0.zip) |
-| v1.2.1 | 2023.11.28 | [Download](https://github.com/scp222thj/MalumMenu/releases/download/v1.2.1/MalumMenu-1.2.1.zip) |
-| v1.2.0 | 2023.11.28 | [Download](https://github.com/scp222thj/MalumMenu/releases/download/v1.2.0/MalumMenu-1.2.0.zip) |
-| v1.1.2 | 2023.7.12 & 2023.7.11 | [Download](https://github.com/scp222thj/MalumMenu/releases/download/v1.1.2/MalumMenu-1.1.2.zip) |
-| v1.1.1 | 2023.7.12 & 2023.7.11 | [Download](https://github.com/scp222thj/MalumMenu/releases/download/v1.1.1/MalumMenu-1.1.1.zip) |
-| v1.1.0 | 2023.7.12 & 2023.7.11 | [Download](https://github.com/scp222thj/MalumMenu/releases/download/v1.1.0/MalumMenu-1.1.0.zip) |
-| v1.0.0 | 2023.7.12 & 2023.7.11 | [Download](https://github.com/scp222thj/MalumMenu/releases/download/v1.0.0/MalumMenu-1.0.0.zip) |
+| v0.0.1 | 2024.3.5 | [Download](https://github.com/lekillerdesgames/MalumMenu-Edited/releases/download/v.0.0.1/MalumMenu.dll) |
 
 
 # ⬇️ Installation
@@ -50,13 +42,18 @@
 3. Paste these files directly into your Among Us game folder.
     - Steam: Right-click Among Us in your Library → Click `Manage` → Click `Browse local files`.
     - Epic Launcher: Right-click Among Us in your Library → Click `Manage` → Click the folder icon in the `Installation` box.
-4. Launch Among Us as you normally would. You should see a console window appear, installing the mod's requirements.
 
-5. Wait for the console window to finish the installation.
+4. Download the latest **MelumMenu-edited dll file** from [here](https://github.com/lekillerdesgames/MalumMenu-Edited/releases/download/v.0.0.1/MalumMenu.dll)
+
+5. Browse to your Among Us game folder then click `Bepinex` → `plugins` and replace the MalumMenu.dll with the one you just downloaded.
    
-6. After installation, Among Us will automatically open with MalumMenu successfully installed.
+6. Launch Among Us as you normally would. You should see a console window appear, installing the mod's requirements.
+
+7. Wait for the console window to finish the installation.
+   
+8. After installation, Among Us will automatically open with MalumMenu successfully installed.
     - By default, you can toggle the cheat gui on by pressing **DELETE** on your keyboard.
-7. If the installation doesn't work, check out our [FAQ](#-faq).
+9. If the installation doesn't work, check out our [FAQ](#-faq).
 
 # 📋 Features
 
@@ -65,6 +62,7 @@
 - An intuitive GUI with our latest, greatest Among Us cheats
 - See ghosts & reveal the impostors
 - Track every player's position using the minimap
+- Revive anyone whenever you want (client sided)
 - Teleport anywhere you want
 - Change your role whenever you please
 - Remove kill cooldown & spam-kill everyone

--- a/src/Cheats/MalumCheats.cs
+++ b/src/Cheats/MalumCheats.cs
@@ -167,6 +167,20 @@ public static class MalumCheats
 
         }
     }
+    public static void reviveAllCheat()
+    {
+        if (CheatToggles.reviveAll){
+
+            // Kill all players by sending a successful MurderPlayer RPC call
+            foreach (var player in PlayerControl.AllPlayerControls)
+            {
+                Utils.revivePlayer(player);
+            }
+
+            CheatToggles.reviveAll = false;
+
+        }
+    }
 
     public static void teleportCursorCheat()
     {

--- a/src/Cheats/MalumCheats.cs
+++ b/src/Cheats/MalumCheats.cs
@@ -171,7 +171,7 @@ public static class MalumCheats
     {
         if (CheatToggles.reviveAll){
 
-            // Kill all players by sending a successful MurderPlayer RPC call
+            // Revive all players
             foreach (var player in PlayerControl.AllPlayerControls)
             {
                 Utils.revivePlayer(player);

--- a/src/Cheats/MalumPPMCheats.cs
+++ b/src/Cheats/MalumPPMCheats.cs
@@ -7,6 +7,7 @@ namespace MalumMenu;
 public static class MalumPPMCheats
 {
     public static bool murderPlayerActive;
+    public static bool revivePlayerActive;
     public static bool spectateActive;
     public static bool teleportPlayerActive;
     public static bool reportBodyActive;
@@ -92,6 +93,47 @@ public static class MalumPPMCheats
         else if (murderPlayerActive)
         {
             murderPlayerActive = false;
+        }
+    }
+
+    public static void revivePlayerPPM()
+    {
+        if (CheatToggles.revivePlayer)
+        {
+            if (!revivePlayerActive)
+            {
+                // Close any player pick menus already open & their cheats
+                if (PlayerPickMenu.playerpickMenu != null)
+                {
+                    PlayerPickMenu.playerpickMenu.Close();
+                    CheatToggles.DisablePPMCheats("revivePlayer");
+                }
+
+                List<GameData.PlayerInfo> playerDataList = new List<GameData.PlayerInfo>();
+
+                // All players are saved to playerList
+                foreach (var player in PlayerControl.AllPlayerControls)
+                {
+                    playerDataList.Add(player.Data);
+                }
+
+                // Player pick menu made for reviving any player
+                PlayerPickMenu.openPlayerPickMenu(playerDataList, (Action)(() =>
+                {
+                    Utils.revivePlayer(PlayerPickMenu.targetPlayerData.Object);
+                }));
+
+                revivePlayerActive = true;
+            }
+
+            // Deactivate cheat if menu is closed
+            if (PlayerPickMenu.playerpickMenu == null){
+                CheatToggles.revivePlayer = false;
+            }
+        }
+        else if (revivePlayerActive)
+        {
+            revivePlayerActive = false;
         }
     }
 

--- a/src/Patches/PlayerPhysicsPatches.cs
+++ b/src/Patches/PlayerPhysicsPatches.cs
@@ -15,11 +15,13 @@ public static class PlayerPhysics_LateUpdate
         MalumCheats.noClipCheat();
         MalumCheats.speedBoostCheat();
         MalumCheats.murderAllCheat();
+        MalumCheats.reviveAllCheat();
         MalumCheats.teleportCursorCheat();
         MalumCheats.completeMyTasksCheat();
 
         MalumPPMCheats.spectatePPM();
         MalumPPMCheats.murderPlayerPPM();
+        MalumPPMCheats.revivePlayerPPM();
         MalumPPMCheats.teleportPlayerPPM();
         MalumPPMCheats.changeRolePPM();
 

--- a/src/UI/CheatToggles.cs
+++ b/src/UI/CheatToggles.cs
@@ -9,7 +9,9 @@ namespace MalumMenu
         public static bool teleportCursor;
         public static bool reportBody;
         public static bool murderPlayer;
+        public static bool revivePlayer;
         public static bool murderAll;
+        public static bool reviveAll;
 
         //Roles
         public static bool changeRole;
@@ -80,13 +82,14 @@ namespace MalumMenu
         {
             reportBody = variableToKeep != "reportBody" ? false : reportBody;
             murderPlayer = variableToKeep != "murderPlayer" ? false : murderPlayer;
+            revivePlayer = variableToKeep != "revivePlayer" ? false : revivePlayer;
             spectate = variableToKeep != "spectate" ? false : spectate;
             changeRole = variableToKeep != "changeRole" ? false : changeRole;
             teleportPlayer = variableToKeep != "teleportPlayer" ? false : teleportPlayer;
         }
 
         public static bool shouldPPMClose(){
-            return !changeRole && !reportBody && !murderPlayer && !spectate && !teleportPlayer;
+            return !changeRole && !reportBody && !murderPlayer && !spectate && !teleportPlayer && !revivePlayer;
         }
     }
 }

--- a/src/UI/MenuUI.cs
+++ b/src/UI/MenuUI.cs
@@ -22,6 +22,10 @@ public class MenuUI : MonoBehaviour
                 new ToggleInfo(" MurderPlayer", () => CheatToggles.murderPlayer, x => CheatToggles.murderPlayer = x),
                 new ToggleInfo(" MurderAll", () => CheatToggles.murderAll, x => CheatToggles.murderAll = x),
             }),
+            new SubmenuInfo("Revive", false, new List<ToggleInfo>() {
+                new ToggleInfo(" RevivePlayer", () => CheatToggles.revivePlayer, x => CheatToggles.revivePlayer = x),
+                new ToggleInfo(" ReviveAll", () => CheatToggles.reviveAll, x => CheatToggles.reviveAll = x),
+            }),
             new SubmenuInfo("Teleport", false, new List<ToggleInfo>() {
                 new ToggleInfo(" to Cursor", () => CheatToggles.teleportCursor, x => CheatToggles.teleportCursor = x),
                 new ToggleInfo(" to Player", () => CheatToggles.teleportPlayer, x => CheatToggles.teleportPlayer = x),
@@ -140,7 +144,7 @@ public class MenuUI : MonoBehaviour
         CheatToggles.unlockFeatures = CheatToggles.freeCosmetics = CheatToggles.avoidBans = true;
 
         if(!Utils.isPlayer){
-            CheatToggles.changeRole = CheatToggles.murderAll = CheatToggles.teleportCursor = CheatToggles.teleportPlayer = CheatToggles.spectate = CheatToggles.freecam = CheatToggles.murderPlayer;
+            CheatToggles.changeRole = CheatToggles.murderAll = CheatToggles.reviveAll = CheatToggles.teleportCursor = CheatToggles.teleportPlayer = CheatToggles.spectate = CheatToggles.freecam = CheatToggles.murderPlayer = CheatToggles.revivePlayer;
         }
 
         //Host-only cheats are turned off if LocalPlayer is not the game's host

--- a/src/Utilities/Utils.cs
+++ b/src/Utilities/Utils.cs
@@ -90,6 +90,12 @@ public static class Utils
         }
     }
 
+    public static void revivePlayer(PlayerControl target)
+    {
+            target.Revive();
+            return;
+    }
+
     // Report bodies using RPC calls
     public static void reportDeadBody(GameData.PlayerInfo playerData)
     {


### PR DESCRIPTION
I found this menu one day ago and found it cool but it was missing something, the ability to revive.
So I decided to code it myself, I tested it and it works pretty well. Note that it's not an rpc means only the client sees players revive, sadly I can't do anything about that but it might be useful because now, if the client wants to revive after being ejected / killed, he can go ahead and even kill again if he's impostor.
Thing I added:
- a new SubMenu named "Revive"
- the ability to revive the selected player (using the shapeshift menu)
- the ability to revive every dead players
Here are some screenshots:

Menu with revive features added:
<img width="164" alt="revive menu" src="https://github.com/scp222thj/MalumMenu/assets/141348096/35265774-4edc-4cec-b9fb-2b0eb3437095">

Menu shown when using the revive player ability:
<img width="960" alt="revive player" src="https://github.com/scp222thj/MalumMenu/assets/141348096/f8b8b190-a3f1-44f0-8507-1fe2480392c4">


Players after using the revive all ability:
<img width="960" alt="revive all" src="https://github.com/scp222thj/MalumMenu/assets/141348096/2727b4e1-44ac-4528-8306-af701e27b642">

Feel free to add my code to the original mod and hope I helped!
My discord: lekillerdesgames

