### PR TITLE
Re-add ChatJailbreak cheat

### DIFF
--- a/src/Patches/ChatControllerPatches.cs
+++ b/src/Patches/ChatControllerPatches.cs
@@ -1,6 +1,7 @@
 using HarmonyLib;
 using System;
 using UnityEngine;
+using System.Text.RegularExpressions;
 
 namespace MalumMenu;
 
@@ -78,19 +79,62 @@ public static class ChatBubble_SetName
     public static void Postfix(ChatBubble __instance){
         MalumESP.chatNametags(__instance);
     }
-}    
+}
+
 
 [HarmonyPatch(typeof(ChatController), nameof(ChatController.Update))]
-public static class ChatController_Update
+public static class ChatJailBreak_FreeChatInputField_OnFieldChanged_Prefix
 {
+    // Postfix patch of FreeChatInputField.OnFieldChanged to unlock extra chat capabilities
     public static void Postfix(ChatController __instance)
     {
-        if (CheatToggles.chatJailbreak)
-        { 
-            if (!__instance.freeChatField.textArea.hasFocus) return;
-            __instance.freeChatField.textArea.AllowPaste = true;
-            __instance.freeChatField.textArea.AllowSymbols = true;
-            __instance.freeChatField.textArea.AllowEmail = true;
+        __instance.freeChatField.textArea.allowAllCharacters = CheatToggles.chatJailbreak; // Not really used by the game's code, but I include it anyway
+        __instance.freeChatField.textArea.AllowPaste = CheatToggles.chatJailbreak; // Allow pasting from clipboard in chat when chatJailbreak is enabled
+        __instance.freeChatField.textArea.AllowSymbols = true; // Allow sending certain symbols
+        __instance.freeChatField.textArea.AllowEmail = CheatToggles.chatJailbreak; // Allow sending email addresses when chatJailbreak is enabled
+        
+        if (CheatToggles.chatJailbreak){
+            __instance.freeChatField.textArea.characterLimit = 119; // Longer message length when chatJailbreak is enabled
+        }else{
+            __instance.freeChatField.textArea.characterLimit = 100;
         }
+        
+    }
+}
+
+[HarmonyPatch(typeof(ChatController), nameof(ChatController.SendFreeChat))]
+public static class ChatController_SendFreeChat
+{
+    // Prefix patch of ChatController.SendFreeChat to unlock extra chat capabilities
+    public static bool Prefix(ChatController __instance)
+    {
+        if (!CheatToggles.chatJailbreak){
+            return true; // Only works if CheatSettings.chatJailbreak is enabled
+        }
+
+        string text = __instance.freeChatField.Text;
+
+        // Replace periods in URLs and email addresses with commas to avoid censorship
+        string modifiedText = CensorUrlsAndEmails(text);
+
+        ChatController.Logger.Debug("SendFreeChat () :: Sending message: '" + modifiedText + "'", null);
+        PlayerControl.LocalPlayer.RpcSendChat(modifiedText);
+
+        return false;
+    }
+
+    private static string CensorUrlsAndEmails(string text)
+    {
+        // Regular expression pattern to match URLs and email addresses
+        string pattern = @"(http[s]?://)?([a-zA-Z0-9-]+\.)+[a-zA-Z]{2,6}(/[\w-./?%&=]*)?|([a-zA-Z0-9_.+-]+@[a-zA-Z0-9-]+\.[a-zA-Z0-9-.]+)";
+        Regex regex = new Regex(pattern);
+
+        // Censor periods in each match
+        return regex.Replace(text, match =>
+        {
+            var censored = match.Value;
+            censored = censored.Replace('.', ',');
+            return censored;
+        });
     }
 }

--- a/src/Patches/ChatControllerPatches.cs
+++ b/src/Patches/ChatControllerPatches.cs
@@ -79,3 +79,18 @@ public static class ChatBubble_SetName
         MalumESP.chatNametags(__instance);
     }
 }    
+
+[HarmonyPatch(typeof(ChatController), nameof(ChatController.Update))]
+public static class ChatController_Update
+{
+    public static void Postfix(ChatController __instance)
+    {
+        if (CheatToggles.chatJailbreak)
+        { 
+            if (!__instance.freeChatField.textArea.hasFocus) return;
+            __instance.freeChatField.textArea.AllowPaste = true;
+            __instance.freeChatField.textArea.AllowSymbols = true;
+            __instance.freeChatField.textArea.AllowEmail = true;
+        }
+    }
+}

--- a/src/Patches/OtherPatches.cs
+++ b/src/Patches/OtherPatches.cs
@@ -18,6 +18,37 @@ public static class PlatformSpecificData_Serialize
     }
 }
 
+[HarmonyPatch(typeof(FreeChatInputField), nameof(FreeChatInputField.UpdateCharCount))]
+public static class FreeChatInputField_UpdateCharCount
+{
+    // Postfix patch of FreeChatInputField.UpdateCharCount to change how charCountText displays
+    public static void Postfix(FreeChatInputField __instance)
+    {
+        if (!CheatToggles.chatJailbreak){
+            return; // Only works if CheatToggles.chatJailbreak is enabled
+        }
+
+        // Update charCountText to account for longer characterLimit
+        
+        int length = __instance.textArea.text.Length;
+        __instance.charCountText.SetText($"{length}/{__instance.textArea.characterLimit}");
+
+        if (length < 90){ // Under 75%
+
+            __instance.charCountText.color = UnityEngine.Color.black;
+        
+        }else if (length < 119){ // Under 100%
+
+            __instance.charCountText.color = new UnityEngine.Color(1f, 1f, 0f, 1f);
+        
+        }else{ // Over or equal to 100%
+
+            __instance.charCountText.color = UnityEngine.Color.red;
+
+        }
+    }
+}
+
 [HarmonyPatch(typeof(SystemInfo), nameof(SystemInfo.deviceUniqueIdentifier), MethodType.Getter)]
 public static class SystemInfo_deviceUniqueIdentifier_Getter
 {

--- a/src/Patches/TextBoxTMPPatches.cs
+++ b/src/Patches/TextBoxTMPPatches.cs
@@ -1,0 +1,23 @@
+using HarmonyLib;
+using UnityEngine;
+
+namespace MalumMenu;
+
+// Allow copying from the chatbox
+[HarmonyPatch(typeof(TextBoxTMP), nameof(TextBoxTMP.Update))]
+public static class TextBoxTMP_Update
+{
+    public static void Postfix(TextBoxTMP __instance)
+    {
+        if (CheatToggles.chatJailbreak)
+        { 
+            if (!__instance.hasFocus){return;}
+
+            // If the user is pressing Ctrl + C, copy the text from the chatbox to the device's clipboard
+            if((Input.GetKey(KeyCode.LeftControl) || Input.GetKey(KeyCode.RightControl)) && Input.GetKeyDown(KeyCode.C))
+            {
+                ClipboardHelper.PutClipboardString(__instance.text);
+            }
+        }
+    }
+}

--- a/src/Patches/TextBoxTMPPatches.cs
+++ b/src/Patches/TextBoxTMPPatches.cs
@@ -3,10 +3,10 @@ using UnityEngine;
 
 namespace MalumMenu;
 
-// Allow copying from the chatbox
 [HarmonyPatch(typeof(TextBoxTMP), nameof(TextBoxTMP.Update))]
 public static class TextBoxTMP_Update
 {
+    // Postfix patch of TextBoxTMP.Update to allow copying from the chatbox
     public static void Postfix(TextBoxTMP __instance)
     {
         if (CheatToggles.chatJailbreak)
@@ -19,5 +19,20 @@ public static class TextBoxTMP_Update
                 ClipboardHelper.PutClipboardString(__instance.text);
             }
         }
+    }
+}
+
+[HarmonyPatch(typeof(TextBoxTMP), nameof(TextBoxTMP.IsCharAllowed))]
+public static class TextBoxTMP_IsCharAllowed
+{
+    // Postfix patch of TextBoxTMP.IsCharAllowed to allow all characters
+    public static bool Prefix(TextBoxTMP __instance, char i, ref bool __result)
+    {
+        if (!CheatToggles.chatJailbreak){
+            return true;
+        }
+
+        __result = !(i == '\b' || i == '>' || i == '<' || i == '\r'); // Some characters cause issues and must therefore be removed
+        return false;
     }
 }

--- a/src/UI/CheatToggles.cs
+++ b/src/UI/CheatToggles.cs
@@ -82,6 +82,7 @@ namespace MalumMenu
         public static bool unlockFeatures = true;
         public static bool freeCosmetics = true;
         public static bool avoidBans = true;
+        public static bool chatJailbreak;
 
         public static void DisablePPMCheats(string variableToKeep)
         {

--- a/src/UI/MenuUI.cs
+++ b/src/UI/MenuUI.cs
@@ -132,7 +132,7 @@ public class MenuUI : MonoBehaviour
         groups.Add(new GroupInfo("Passive", false, new List<ToggleInfo>() {
             new ToggleInfo(" Free Cosmetics", () => CheatToggles.freeCosmetics, x => CheatToggles.freeCosmetics = x),
             new ToggleInfo(" Avoid Penalties", () => CheatToggles.avoidBans, x => CheatToggles.avoidBans = x),
-            new ToggleInfo(" Unlock Features", () => CheatToggles.unlockFeatures, x => CheatToggles.unlockFeatures = x)
+            new ToggleInfo(" Unlock Extra Features", () => CheatToggles.unlockFeatures, x => CheatToggles.unlockFeatures = x)
         }, new List<SubmenuInfo>()));
     }
 

--- a/src/UI/MenuUI.cs
+++ b/src/UI/MenuUI.cs
@@ -34,7 +34,6 @@ public class MenuUI : MonoBehaviour
             new ToggleInfo(" See Ghosts", () => CheatToggles.seeGhosts, x => CheatToggles.seeGhosts = x),
             new ToggleInfo(" No Shadows", () => CheatToggles.fullBright, x => CheatToggles.fullBright = x),
             new ToggleInfo(" Reveal Votes", () => CheatToggles.revealVotes, x => CheatToggles.revealVotes = x),
-            new ToggleInfo(" Always Chat", () => CheatToggles.alwaysChat, x => CheatToggles.alwaysChat = x)
         }, new List<SubmenuInfo> {
             new SubmenuInfo("Camera", false, new List<ToggleInfo>() {
                 new ToggleInfo(" Zoom Out", () => CheatToggles.zoomOut, x => CheatToggles.zoomOut = x),
@@ -110,6 +109,11 @@ public class MenuUI : MonoBehaviour
             }),
         }));
 
+        groups.Add(new GroupInfo("Chat", false, new List<ToggleInfo>() {
+            new ToggleInfo(" Enable Chat", () => CheatToggles.alwaysChat, x => CheatToggles.alwaysChat = x),
+            new ToggleInfo(" Unlock Textbox", () => CheatToggles.chatJailbreak, x => CheatToggles.chatJailbreak = x)
+        }, new List<SubmenuInfo>()));
+
         // Host-Only cheats are temporarly disabled because of some bugs
 
         //groups.Add(new GroupInfo("Host-Only", false, new List<ToggleInfo>() {
@@ -128,8 +132,7 @@ public class MenuUI : MonoBehaviour
         groups.Add(new GroupInfo("Passive", false, new List<ToggleInfo>() {
             new ToggleInfo(" Free Cosmetics", () => CheatToggles.freeCosmetics, x => CheatToggles.freeCosmetics = x),
             new ToggleInfo(" Avoid Penalties", () => CheatToggles.avoidBans, x => CheatToggles.avoidBans = x),
-            new ToggleInfo(" Unlock Features", () => CheatToggles.unlockFeatures, x => CheatToggles.unlockFeatures = x),
-            new ToggleInfo(" Chat Jailbreak", () => CheatToggles.chatJailbreak, x => CheatToggles.chatJailbreak = x),
+            new ToggleInfo(" Unlock Features", () => CheatToggles.unlockFeatures, x => CheatToggles.unlockFeatures = x)
         }, new List<SubmenuInfo>()));
     }
 

--- a/src/UI/MenuUI.cs
+++ b/src/UI/MenuUI.cs
@@ -129,6 +129,7 @@ public class MenuUI : MonoBehaviour
             new ToggleInfo(" Free Cosmetics", () => CheatToggles.freeCosmetics, x => CheatToggles.freeCosmetics = x),
             new ToggleInfo(" Avoid Penalties", () => CheatToggles.avoidBans, x => CheatToggles.avoidBans = x),
             new ToggleInfo(" Unlock Features", () => CheatToggles.unlockFeatures, x => CheatToggles.unlockFeatures = x),
+            new ToggleInfo(" Chat Jailbreak", () => CheatToggles.chatJailbreak, x => CheatToggles.chatJailbreak = x),
         }, new List<SubmenuInfo>()));
     }
 


### PR DESCRIPTION
features:
- allow copy-pasting to and from the chat bubble
- allow sending symbols and email addresses in chat

