### PR TITLE
Added Panic mode

### DIFF
--- a/src/Cheats/MalumCheats.cs
+++ b/src/Cheats/MalumCheats.cs
@@ -1,18 +1,25 @@
+using HarmonyLib;
 using Sentry.Internal.Extensions;
+using System;
 using UnityEngine;
+using UnityEngine.SceneManagement;
 
 namespace MalumMenu;
 public static class MalumCheats
 {
+    private static LoadSceneMode scene;
+
     public static void closeMeetingCheat()
     {
-        if(CheatToggles.closeMeeting){
-            
-            if (MeetingHud.Instance){ // Closes MeetingHud window if it's open
+        if (CheatToggles.closeMeeting)
+        {
+
+            if (MeetingHud.Instance)
+            { // Closes MeetingHud window if it's open
 
                 // Destroy MeetingHud window gameobject
                 MeetingHud.Instance.DespawnOnDestroy = false;
-                Object.Destroy(MeetingHud.Instance.gameObject);
+                UnityEngine.Object.Destroy(MeetingHud.Instance.gameObject);
 
                 // Gameplay must be reenabled
                 DestroyableSingleton<HudManager>.Instance.StartCoroutine(DestroyableSingleton<HudManager>.Instance.CoFadeFullScreen(Color.black, Color.clear, 0.2f, false));
@@ -22,25 +29,29 @@ public static class MalumCheats
                 DestroyableSingleton<HudManager>.Instance.SetHudActive(true);
                 ControllerManager.Instance.CloseAndResetAll();
 
-            }else if (ExileController.Instance != null){ // Ends exile cutscene if it's playing
+            }
+            else if (ExileController.Instance != null)
+            { // Ends exile cutscene if it's playing
                 ExileController.Instance.ReEnableGameplay();
                 ExileController.Instance.WrapUp();
             }
-            
+
             CheatToggles.closeMeeting = false; // Button behaviour
         }
     }
 
     public static void noKillCdCheat(PlayerControl playerControl)
     {
-        if (CheatToggles.zeroKillCd && playerControl.killTimer > 0f){
+        if (CheatToggles.zeroKillCd && playerControl.killTimer > 0f)
+        {
             playerControl.SetKillTimer(0f);
         }
     }
 
     public static void completeMyTasksCheat()
     {
-        if (CheatToggles.completeMyTasks){
+        if (CheatToggles.completeMyTasks)
+        {
             Utils.completeMyTasks();
 
             CheatToggles.completeMyTasks = false;
@@ -49,21 +60,26 @@ public static class MalumCheats
 
     public static void engineerCheats(EngineerRole engineerRole)
     {
-        if (CheatToggles.endlessVentTime){
+        if (CheatToggles.endlessVentTime)
+        {
 
             // Makes vent time so incredibly long (float.MaxValue) so that it never ends
             engineerRole.inVentTimeRemaining = float.MaxValue;
-        
-        // Vent time is reset to normal value after the cheat is disabled
-        }else if (engineerRole.inVentTimeRemaining > engineerRole.GetCooldown()){
-            
+
+            // Vent time is reset to normal value after the cheat is disabled
+        }
+        else if (engineerRole.inVentTimeRemaining > engineerRole.GetCooldown())
+        {
+
             engineerRole.inVentTimeRemaining = engineerRole.GetCooldown();
-        
+
         }
 
-        if (CheatToggles.noVentCooldown){
+        if (CheatToggles.noVentCooldown)
+        {
 
-            if (engineerRole.cooldownSecondsRemaining > 0f){
+            if (engineerRole.cooldownSecondsRemaining > 0f)
+            {
 
                 engineerRole.cooldownSecondsRemaining = 0f;
 
@@ -71,48 +87,56 @@ public static class MalumCheats
                 DestroyableSingleton<HudManager>.Instance.AbilityButton.SetCooldownFill(0f);
 
             }
-        
+
         }
     }
 
     public static void shapeshifterCheats(ShapeshifterRole shapeshifterRole)
     {
-        if (CheatToggles.endlessSsDuration){
+        if (CheatToggles.endlessSsDuration)
+        {
 
             // Makes shapeshift duration so incredibly long (float.MaxValue) so that it never ends
-            shapeshifterRole.durationSecondsRemaining = float.MaxValue; 
-            
-        // Shapeshift duration is reset to normal value after the cheat is disabled
-        }else if (shapeshifterRole.durationSecondsRemaining > GameManager.Instance.LogicOptions.GetShapeshifterDuration()){
-            
+            shapeshifterRole.durationSecondsRemaining = float.MaxValue;
+
+            // Shapeshift duration is reset to normal value after the cheat is disabled
+        }
+        else if (shapeshifterRole.durationSecondsRemaining > GameManager.Instance.LogicOptions.GetShapeshifterDuration())
+        {
+
             shapeshifterRole.durationSecondsRemaining = GameManager.Instance.LogicOptions.GetShapeshifterDuration();
-        
+
         }
     }
 
     public static void scientistCheats(ScientistRole scientistRole)
     {
-        if (CheatToggles.noVitalsCooldown){
+        if (CheatToggles.noVitalsCooldown)
+        {
 
             scientistRole.currentCooldown = 0f;
         }
 
-        if (CheatToggles.endlessBattery){
+        if (CheatToggles.endlessBattery)
+        {
 
             // Makes vitals battery so incredibly long (float.MaxValue) so that it never ends
             scientistRole.currentCharge = float.MaxValue;
 
-        // Battery charge is reset to normal value after the cheat is disabled
-        }else if (scientistRole.currentCharge > scientistRole.RoleCooldownValue){
-            
+            // Battery charge is reset to normal value after the cheat is disabled
+        }
+        else if (scientistRole.currentCharge > scientistRole.RoleCooldownValue)
+        {
+
             scientistRole.currentCharge = scientistRole.RoleCooldownValue;
-        
+
         }
     }
 
     public static void trackerCheats(TrackerRole trackerRole)
     {
-        if (CheatToggles.noTrackingCooldown){
+        if (CheatToggles.noTrackingCooldown)
+        {
 
             trackerRole.cooldownSecondsRemaining = 0f;
             trackerRole.delaySecondsRemaining = 0f;
@@ -122,22 +146,26 @@ public static class MalumCheats
 
         }
 
-        if (CheatToggles.noTrackingDelay){
+        if (CheatToggles.noTrackingDelay)
+        {
 
             MapBehaviour.Instance.trackedPointDelayTime = GameManager.Instance.LogicOptions.GetTrackerDelay();
 
         }
 
-        if (CheatToggles.endlessTracking){
+        if (CheatToggles.endlessTracking)
+        {
 
             // Makes vitals battery so incredibly long (float.MaxValue) so that it never ends
             trackerRole.durationSecondsRemaining = float.MaxValue;
 
-        // Battery charge is reset to normal value after the cheat is disabled
-        }else if (trackerRole.durationSecondsRemaining > GameManager.Instance.LogicOptions.GetTrackerDuration()){
-            
+            // Battery charge is reset to normal value after the cheat is disabled
+        }
+        else if (trackerRole.durationSecondsRemaining > GameManager.Instance.LogicOptions.GetTrackerDuration())
+        {
+
             trackerRole.durationSecondsRemaining = GameManager.Instance.LogicOptions.GetTrackerDuration();
-        
+
         }
     }
     public static void phantomCheats(PhantomRole phantomRole)
@@ -148,16 +176,19 @@ public static class MalumCheats
     public static void useVentCheat(HudManager hudManager)
     {
         // try-catch to prevent errors when role is null
-        try{
+        try
+        {
 
-			// Engineers & Impostors don't need this cheat so it is disabled for them
-			// Ghost venting causes issues so it is also disabled
+            // Engineers & Impostors don't need this cheat so it is disabled for them
+            // Ghost venting causes issues so it is also disabled
 
-			if (!PlayerControl.LocalPlayer.Data.Role.CanVent && !PlayerControl.LocalPlayer.Data.IsDead){
-				hudManager.ImpostorVentButton.gameObject.SetActive(CheatToggles.useVents);
-			}
+            if (!PlayerControl.LocalPlayer.Data.Role.CanVent && !PlayerControl.LocalPlayer.Data.IsDead)
+            {
+                hudManager.ImpostorVentButton.gameObject.SetActive(CheatToggles.useVents);
+            }
 
-        }catch{}
+        }
+        catch { }
     }
 
     public static void sabotageCheat(ShipStatus shipStatus)
@@ -175,21 +206,26 @@ public static class MalumCheats
 
     public static void walkInVentCheat()
     {
-        try{
+        try
+        {
 
-            if (CheatToggles.walkVent){
+            if (CheatToggles.walkVent)
+            {
                 PlayerControl.LocalPlayer.inVent = false;
                 PlayerControl.LocalPlayer.moveable = true;
             }
 
-        }catch{}
+        }
+        catch { }
     }
 
     public static void kickVentsCheat()
     {
-        if (CheatToggles.kickVents){
+        if (CheatToggles.kickVents)
+        {
 
-            foreach(var vent in ShipStatus.Instance.AllVents){
+            foreach (var vent in ShipStatus.Instance.AllVents)
+            {
 
                 VentilationSystem.Update(VentilationSystem.Operation.BootImpostors, vent.Id);
 
@@ -201,13 +237,17 @@ public static class MalumCheats
 
     public static void killAllCheat()
     {
-        if (CheatToggles.killAll){
+        if (CheatToggles.killAll)
+        {
 
-            if (Utils.isLobby){
+            if (Utils.isLobby)
+            {
 
                 HudManager.Instance.Notifier.AddDisconnectMessage("Killing in lobby disabled for being too buggy");
 
-            }else{
+            }
+            else
+            {
 
                 // Kill all players by sending a successful MurderPlayer RPC call
                 foreach (var player in PlayerControl.AllPlayerControls)
@@ -224,18 +264,23 @@ public static class MalumCheats
 
     public static void killAllCrewCheat()
     {
-        if (CheatToggles.killAllCrew){
+        if (CheatToggles.killAllCrew)
+        {
 
-            if (Utils.isLobby){
+            if (Utils.isLobby)
+            {
 
                 HudManager.Instance.Notifier.AddDisconnectMessage("Killing in lobby disabled for being too buggy");
 
-            }else{
+            }
+            else
+            {
 
                 // Kill all players by sending a successful MurderPlayer RPC call
                 foreach (var player in PlayerControl.AllPlayerControls)
                 {
-                    if (player.Data.Role.TeamType == RoleTeamTypes.Crewmate){
+                    if (player.Data.Role.TeamType == RoleTeamTypes.Crewmate)
+                    {
                         Utils.murderPlayer(player, MurderResultFlags.Succeeded);
                     }
                 }
@@ -249,18 +294,23 @@ public static class MalumCheats
 
     public static void killAllImpsCheat()
     {
-        if (CheatToggles.killAllImps){
+        if (CheatToggles.killAllImps)
+        {
 
-            if (Utils.isLobby){
+            if (Utils.isLobby)
+            {
 
                 HudManager.Instance.Notifier.AddDisconnectMessage("Killing in lobby disabled for being too buggy");
 
-            }else{
+            }
+            else
+            {
 
                 // Kill all players by sending a successful MurderPlayer RPC call
                 foreach (var player in PlayerControl.AllPlayerControls)
                 {
-                    if (player.Data.Role.TeamType == RoleTeamTypes.Impostor){
+                    if (player.Data.Role.TeamType == RoleTeamTypes.Impostor)
+                    {
                         Utils.murderPlayer(player, MurderResultFlags.Succeeded);
                     }
                 }
@@ -277,7 +327,7 @@ public static class MalumCheats
         if (CheatToggles.teleportCursor)
         {
             // Teleport player to cursor's in-world position on right-click
-            if (Input.GetMouseButtonDown(1)) 
+            if (Input.GetMouseButtonDown(1))
             {
                 PlayerControl.LocalPlayer.NetTransform.RpcSnapTo(Camera.main.ScreenToWorldPoint(Input.mousePosition));
             }
@@ -286,11 +336,13 @@ public static class MalumCheats
 
     public static void noClipCheat()
     {
-        try{
+        try
+        {
 
             PlayerControl.LocalPlayer.Collider.enabled = !(CheatToggles.noClip || PlayerControl.LocalPlayer.onLadder);
 
-        }catch{}
+        }
+        catch { }
     }
 
     public static void speedBoostCheat()
@@ -311,7 +363,85 @@ public static class MalumCheats
             PlayerControl.LocalPlayer.MyPhysics.Speed = newSpeed;
             PlayerControl.LocalPlayer.MyPhysics.GhostSpeed = newGhostSpeed;
         }
-        catch{}
+        catch { }
     }
 
+    public static void PanicMode() //panic mode funktions
+    {
+        CheatToggles.noClip = false;
+        CheatToggles.speedBoost = false;
+        CheatToggles.teleportPlayer = false;
+        CheatToggles.teleportCursor = false;
+        CheatToggles.reportBody = false;
+        CheatToggles.killPlayer = false;
+        CheatToggles.telekillPlayer = false;
+        CheatToggles.killAll = false;
+        CheatToggles.killAllCrew = false;
+        CheatToggles.killAllImps = false;
+
+        CheatToggles.changeRole = false;
+        CheatToggles.zeroKillCd = false;
+        CheatToggles.completeMyTasks = false;
+        CheatToggles.killReach = false;
+        CheatToggles.killAnyone = false;
+        CheatToggles.endlessSsDuration = false;
+        CheatToggles.endlessBattery = false;
+        CheatToggles.endlessTracking = false;
+        CheatToggles.noTrackingCooldown = false;
+        CheatToggles.noTrackingDelay = false;
+        CheatToggles.noVitalsCooldown = false;
+        CheatToggles.noVentCooldown = false;
+        CheatToggles.endlessVentTime = false;
+        CheatToggles.endlessVanish = false;
+        CheatToggles.killVanished = false;
+        CheatToggles.noVanishAnim = false;
+        CheatToggles.noShapeshiftAnim = false;
+
+        CheatToggles.fullBright = false;
+        CheatToggles.alwaysChat = false;
+        CheatToggles.seeGhosts = false;
+        CheatToggles.seeRoles = false;
+        CheatToggles.seeDisguises = false;
+        CheatToggles.revealVotes = false;
+
+        CheatToggles.spectate = false;
+        CheatToggles.zoomOut = false;
+        CheatToggles.freecam = false;
+
+        CheatToggles.mapCrew = false;
+        CheatToggles.mapImps = false;
+        CheatToggles.mapGhosts = false;
+        CheatToggles.colorBasedMap = false;
+
+        CheatToggles.tracersImps = false;
+        CheatToggles.tracersCrew = false;
+        CheatToggles.tracersGhosts = false;
+        CheatToggles.tracersBodies = false;
+        CheatToggles.colorBasedTracers = false;
+        CheatToggles.distanceBasedTracers = false;
+
+        CheatToggles.closeMeeting = false;
+        CheatToggles.doorsSab = false;
+        CheatToggles.unfixableLights = false;
+        CheatToggles.commsSab = false;
+        CheatToggles.elecSab = false;
+        CheatToggles.reactorSab = false;
+        CheatToggles.oxygenSab = false;
+        CheatToggles.mushSab = false;
+
+        CheatToggles.useVents = false;
+        CheatToggles.walkVent = false;
+        CheatToggles.kickVents = false;
+
+        // Host-Only settings can be included if needed
+        // CheatToggles.impostorHack = false;
+        // CheatToggles.godMode = false;
+        // CheatToggles.evilVote = false;
+        // CheatToggles.voteImmune = false;
+
+        CheatToggles.unlockFeatures = false;
+        CheatToggles.freeCosmetics = false;
+        CheatToggles.avoidBans = false;
+        ModManager.Instance.ModStamp.enabled = false;
+    }
 }

--- a/src/Patches/OtherPatches.cs
+++ b/src/Patches/OtherPatches.cs
@@ -25,7 +25,8 @@ public static class SystemInfo_deviceUniqueIdentifier_Getter
     // Made to hide the user's real unique deviceId by generating a random fake one
     public static void Postfix(ref string __result)
     {
-        if (MalumMenu.spoofDeviceId.Value){
+        if (MalumMenu.spoofDeviceId.Value)
+        {
 
             var bytes = new byte[16];
             using (var rng = RandomNumberGenerator.Create())
@@ -36,7 +37,7 @@ public static class SystemInfo_deviceUniqueIdentifier_Getter
             __result = BitConverter.ToString(bytes).Replace("-", "").ToLower();
 
         }
-        
+
     }
 }
 
@@ -48,7 +49,8 @@ public static class AmongUsClient_Update
         MalumSpoof.spoofLevel();
 
         // Code to treat temp accounts the same as full accounts, including access to friend codes
-        if (EOSManager.Instance.loginFlowFinished && MalumMenu.guestMode.Value){
+        if (EOSManager.Instance.loginFlowFinished && MalumMenu.guestMode.Value)
+        {
 
             DataManager.Player.Account.LoginStatus = EOSManager.AccountLoginStatus.LoggedIn;
 
@@ -71,14 +73,22 @@ public static class VersionShower_Start
     // Postfix patch of VersionShower.Start to show MalumMenu version
     public static void Postfix(VersionShower __instance)
     {
-        if (MalumMenu.supportedAU.Contains(Application.version)){ // Checks if Among Us version is supported
+        if (CheatToggles.panicMode == true)
+        { //checks if panic mode is enabled
+            __instance.text.text = $"v2024.8.13s (build num:4431)";
 
-            __instance.text.text =  $"MalumMenu v{MalumMenu.malumVersion} (v{Application.version})"; // Supported
-        
-        }else{
+        }
+        else if (MalumMenu.supportedAU.Contains(Application.version))
+        { // Checks if Among Us version is supported
 
-            __instance.text.text =  $"MalumMenu v{MalumMenu.malumVersion} (<color=red>v{Application.version}</color>)"; //Unsupported
-        
+            __instance.text.text = $"MalumMenu v{MalumMenu.malumVersion} (v{Application.version})"; // Supported
+
+        }
+        else
+        {
+
+            __instance.text.text = $"MalumMenu v{MalumMenu.malumVersion} (<color=red>v{Application.version}</color>)"; //Unsupported
+
         }
     }
 }
@@ -91,27 +101,37 @@ public static class PingTracker_Update
     {
         __instance.text.alignment = TMPro.TextAlignmentOptions.Center;
 
-        if (AmongUsClient.Instance.IsGameStarted){
+        // Check if panic mode is enabled
+        if (CheatToggles.panicMode == true)
+        {
+            // Do not show "MalumMenu by scp222thj" & colored ping if panic mode is enabled
 
+            return;
+        }
+        else if (AmongUsClient.Instance.IsGameStarted)
+        {
             __instance.aspectPosition.DistanceFromEdge = new Vector3(-0.21f, 0.50f, 0f);
 
             __instance.text.text = $"MalumMenu by scp222thj ~ {Utils.getColoredPingText(AmongUsClient.Instance.Ping)}";
-            
+
             return;
         }
 
         __instance.text.text = $"MalumMenu by scp222thj\n{Utils.getColoredPingText(AmongUsClient.Instance.Ping)}";
-        
     }
+
+
 }
+
 
 [HarmonyPatch(typeof(HatManager), nameof(HatManager.Initialize))]
 public static class HatManager_Initialize
 {
-    public static void Postfix(HatManager __instance){
+    public static void Postfix(HatManager __instance)
+    {
 
         CosmeticsUnlocker.unlockCosmetics(__instance);
-        
+
     }
 }
 
@@ -121,7 +141,8 @@ public static class StatsManager_BanMinutesLeft_Getter
     // Prefix patch of Getter method for StatsManager.BanMinutesLeft to remove disconnect penalty
     public static void Postfix(StatsManager __instance, ref int __result)
     {
-        if (CheatToggles.avoidBans){
+        if (CheatToggles.avoidBans)
+        {
             __instance.BanPoints = 0f; // Removes all BanPoints
             __result = 0; // Removes all BanMinutes
         }
@@ -134,7 +155,8 @@ public static class FullAccount_CanSetCustomName
     // Prefix patch of FullAccount.CanSetCustomName to allow the usage of custom names
     public static void Prefix(ref bool canSetName)
     {
-        if (CheatToggles.unlockFeatures){ 
+        if (CheatToggles.unlockFeatures)
+        {
             canSetName = true;
         }
     }
@@ -146,7 +168,8 @@ public static class AccountManager_CanPlayOnline
     // Prefix patch of AccountManager.CanPlayOnline to allow online games
     public static void Postfix(ref bool __result)
     {
-        if (CheatToggles.unlockFeatures){
+        if (CheatToggles.unlockFeatures)
+        {
             __result = true;
         }
     }
@@ -158,7 +181,8 @@ public static class InnerNet_InnerNetClient_JoinGame
     // Prefix patch of InnerNet.InnerNetClient.JoinGame to allow online games
     public static void Prefix()
     {
-        if (CheatToggles.unlockFeatures){
+        if (CheatToggles.unlockFeatures)
+        {
             DataManager.Player.Account.LoginStatus = EOSManager.AccountLoginStatus.LoggedIn;
         }
     }
@@ -180,20 +204,22 @@ public static class Vent_CanUse
     // Basically does what the original method did with the required modifications
     public static void Postfix(Vent __instance, NetworkedPlayerInfo pc, ref bool canUse, ref bool couldUse, ref float __result)
     {
-        if (!PlayerControl.LocalPlayer.Data.Role.CanVent && !PlayerControl.LocalPlayer.Data.IsDead){
-            if (CheatToggles.useVents){
+        if (!PlayerControl.LocalPlayer.Data.Role.CanVent && !PlayerControl.LocalPlayer.Data.IsDead)
+        {
+            if (CheatToggles.useVents)
+            {
                 float num = float.MaxValue;
                 PlayerControl @object = pc.Object;
 
                 Vector3 center = @object.Collider.bounds.center;
-		        Vector3 position = __instance.transform.position;
-		        num = Vector2.Distance(center, position);
-            
+                Vector3 position = __instance.transform.position;
+                num = Vector2.Distance(center, position);
+
                 // Allow usage of vents unless the vent is too far or there are objects blocking the player's path
                 canUse = num <= __instance.UsableDistance && !PhysicsHelpers.AnythingBetween(@object.Collider, center, position, Constants.ShipOnlyMask, false);
                 couldUse = true;
                 __result = num;
-            }    
+            }
         }
     }
 }

--- a/src/UI/CheatToggles.cs
+++ b/src/UI/CheatToggles.cs
@@ -59,7 +59,7 @@ namespace MalumMenu
         public static bool tracersBodies;
         public static bool colorBasedTracers;
         public static bool distanceBasedTracers;
-        
+
         //Ship
         public static bool closeMeeting;
         public static bool doorsSab;
@@ -86,6 +86,9 @@ namespace MalumMenu
         public static bool freeCosmetics = true;
         public static bool avoidBans = true;
 
+        //Other
+        public static bool panicMode;
+
         public static void DisablePPMCheats(string variableToKeep)
         {
             reportBody = variableToKeep != "reportBody" ? false : reportBody;
@@ -96,7 +99,8 @@ namespace MalumMenu
             teleportPlayer = variableToKeep != "teleportPlayer" ? false : teleportPlayer;
         }
 
-        public static bool shouldPPMClose(){
+        public static bool shouldPPMClose()
+        {
             return !changeRole && !reportBody && !telekillPlayer && !killPlayer && !spectate && !teleportPlayer;
         }
     }

--- a/src/UI/MenuUI.cs
+++ b/src/UI/MenuUI.cs
@@ -61,7 +61,7 @@ public class MenuUI : MonoBehaviour
 
         groups.Add(new GroupInfo("Roles", false, new List<ToggleInfo>() {
             new ToggleInfo(" Set Fake Role", () => CheatToggles.changeRole, x => CheatToggles.changeRole = x),
-        }, 
+        },
             new List<SubmenuInfo> {
                 new SubmenuInfo("Impostor", false, new List<ToggleInfo>() {
                     new ToggleInfo(" Kill Anyone", () => CheatToggles.killAnyone, x => CheatToggles.killAnyone = x),
@@ -133,24 +133,56 @@ public class MenuUI : MonoBehaviour
             new ToggleInfo(" Avoid Penalties", () => CheatToggles.avoidBans, x => CheatToggles.avoidBans = x),
             new ToggleInfo(" Unlock Extra Features", () => CheatToggles.unlockFeatures, x => CheatToggles.unlockFeatures = x),
         }, new List<SubmenuInfo>()));
+
+        groups.Add(new GroupInfo("Other", false, new List<ToggleInfo>() {
+            new ToggleInfo("Panic Mode", () => CheatToggles.panicMode, x => CheatToggles.panicMode = x),
+        }, new List<SubmenuInfo>()));
     }
 
-    private void Update(){
+
+
+    private void Update()
+    {
+
+        if (CheatToggles.panicMode == true)
+        {
+
+            // Disables the GUI if panicMode is enabled
+            isGUIActive = false;
+            MalumCheats.PanicMode();
+        }
 
         if (Input.GetKeyDown(Utils.stringToKeycode(MalumMenu.menuKeybind.Value)))
         {
-            //Enable-disable GUI with DELETE key
-            isGUIActive = !isGUIActive;
 
-            //Also teleport the window to the mouse for immediate use
-            Vector2 mousePosition = Input.mousePosition;
-            windowRect.position = new Vector2(mousePosition.x, Screen.height - mousePosition.y);
+            if (CheatToggles.panicMode == true)
+            {
+                // Keeps the GUI disabled and unopenable when panic mode is active
+                isGUIActive = false;
+
+
+            }
+            else
+            {
+
+                // Enable-disable GUI with the keybind if panic mode is not active
+                isGUIActive = !isGUIActive;
+
+                // Also teleport the window to the mouse for immediate use
+                if (isGUIActive)
+                {
+                    Vector2 mousePosition = Input.mousePosition;
+                    windowRect.position = new Vector2(mousePosition.x, Screen.height - mousePosition.y);
+                }
+            }
         }
+
 
         //Passive cheats are always on to avoid problems
         CheatToggles.unlockFeatures = CheatToggles.freeCosmetics = CheatToggles.avoidBans = true;
 
-        if(!Utils.isPlayer){
+        if (!Utils.isPlayer)
+        {
             CheatToggles.changeRole = CheatToggles.killAll = CheatToggles.telekillPlayer = CheatToggles.killAllCrew = CheatToggles.killAllImps = CheatToggles.teleportCursor = CheatToggles.teleportPlayer = CheatToggles.spectate = CheatToggles.freecam = CheatToggles.killPlayer;
         }
 
@@ -160,7 +192,8 @@ public class MenuUI : MonoBehaviour
         //}
 
         //Some cheats only work if the ship is present, so they are turned off if it is not
-        if(!Utils.isShip){
+        if (!Utils.isShip)
+        {
             CheatToggles.unfixableLights = CheatToggles.completeMyTasks = CheatToggles.kickVents = CheatToggles.reportBody = CheatToggles.closeMeeting = CheatToggles.reactorSab = CheatToggles.oxygenSab = CheatToggles.commsSab = CheatToggles.elecSab = CheatToggles.mushSab = CheatToggles.doorsSab = false;
         }
     }


### PR DESCRIPTION
#### **CheatToggles.cs**
  - Introduced a new category: `Other`.
  - Added a new public static toggle: `panicMode = false`.

#### **MenuUI.cs**
  - Implemented logic at line 140 to disable the GUI when `panicMode` is enabled.
  - Added a new group titled "Other" to the menu UI.
  - Included a cheat toggle for `Panic Mode` under the "Other" category.

#### **OtherPatches.cs**
  - At line 70, the displayed version changes to "Among Us Version" when `panicMode` is enabled, replacing the "Malum Menu Version".
  - At line 95, the text "MalumMenu by scp222thj" is hidden in-game when `panicMode` is active.

#### **MalumCheats.cs**
  - Added `PanicMode` logic at line 369:
    - Disables all cheats.
    - Sets `ModManager.Instance.ModStamp.enabled` to `false`, effectively hiding the mod stamp.

#### **Important Notice:**
- When `Panic Mode` is activated:
  - The "MalumMenu by scp222thj" text will be hidden.
  - Upon exiting the game, the "Malum Menu Version" will be replaced by the "Among Us Build Version".
  - The GUI cannot be reopened after it has been closed. 
  - The Modstamp will be hidden

This update adds a Panic feature to quickly disable cheats and remove mod indicators, to hide from screenshare.