### PR TITLE
Added option to disable passives in config

### DIFF
--- a/src/MalumMenu.cs
+++ b/src/MalumMenu.cs
@@ -27,6 +27,9 @@ public partial class MalumMenu : BasePlugin
     public static ConfigEntry<string> guestFriendCode;
     public static ConfigEntry<bool> guestMode;
     public static ConfigEntry<bool> noTelemetry;
+    public static ConfigEntry<bool> freeCosmetics;
+    public static ConfigEntry<bool> avoidBans;
+    public static ConfigEntry<bool> unlockFeatures;
 
     public override void Load()
     {
@@ -71,6 +74,25 @@ public partial class MalumMenu : BasePlugin
                                 "NoTelemetry",
                                 true,
                                 "When enabled it will stop Among Us from collecting analytics of your games and sending them to Innersloth using Unity Analytics");
+
+        freeCosmetics = Config.Bind("MalumMenu.FreeCosmetics",
+                               "FreeCosmetics",
+                               true,
+                               "When enabled it gives you access to all of the game's cosmetics for free");
+
+        avoidBans = Config.Bind("MalumMenu.AvoidBans",
+                              "AvoidBans",
+                              true,
+                              "When enabled it removes the penalty you receive when disconnecting from games early");
+
+        unlockFeatures = Config.Bind("MalumMenu.UnlockFeatures",
+                              "UnlockFeatures",
+                              true,
+                              "When enabled it will Unlocks many of the game's special features automatically, including: Freechat, Friend list, Custom name and Online gameplay");
+
+        CheatToggles.unlockFeatures = unlockFeatures.Value;
+        CheatToggles.freeCosmetics = freeCosmetics.Value;
+        CheatToggles.avoidBans = avoidBans.Value;
 
 
 

--- a/src/UI/CheatToggles.cs
+++ b/src/UI/CheatToggles.cs
@@ -82,9 +82,9 @@ namespace MalumMenu
         //public static bool voteImmune;
 
         //Passive
-        public static bool unlockFeatures = true;
-        public static bool freeCosmetics = true;
-        public static bool avoidBans = true;
+        public static bool unlockFeatures;
+        public static bool freeCosmetics;
+        public static bool avoidBans;
 
         public static void DisablePPMCheats(string variableToKeep)
         {

--- a/src/UI/MenuUI.cs
+++ b/src/UI/MenuUI.cs
@@ -148,9 +148,15 @@ public class MenuUI : MonoBehaviour
         }
 
         //Passive cheats are always on to avoid problems
-        CheatToggles.unlockFeatures = CheatToggles.freeCosmetics = CheatToggles.avoidBans = true;
+        //CheatToggles.unlockFeatures = CheatToggles.freeCosmetics = CheatToggles.avoidBans = true;
 
-        if(!Utils.isPlayer){
+        //Passive cheats are always toggled by the config to avoid problems
+        CheatToggles.unlockFeatures = MalumMenu.unlockFeatures.Value;
+        CheatToggles.freeCosmetics = MalumMenu.freeCosmetics.Value;
+        CheatToggles.avoidBans = MalumMenu.avoidBans.Value;
+
+
+        if (!Utils.isPlayer){
             CheatToggles.changeRole = CheatToggles.killAll = CheatToggles.telekillPlayer = CheatToggles.killAllCrew = CheatToggles.killAllImps = CheatToggles.teleportCursor = CheatToggles.teleportPlayer = CheatToggles.spectate = CheatToggles.freecam = CheatToggles.killPlayer;
         }
 


### PR DESCRIPTION
---

### **Changes in `MalumMenu.cs`**

- **Lines 30-32**:  
  Added entries to the list for `"freeCosmetics"`, `"avoidBans"`, and `"unlockFeatures"`.

- **Lines 78-92**:  
  Added bindings and descriptions for new features, ensuring compliance with the descriptions provided in the [Features list](https://github.com/scp222thj/MalumMenu/blob/main/FEATURES.md).

- **Lines 93-95**:  
  Implemented a function to update the corresponding boolean values based on the configuration settings.

---

### **Changes in `CheatToggles.cs`**

- Removed the `= true` default assignments from `"freeCosmetics"`, `"avoidBans"`, and `"unlockFeatures"`.

---

### **Changes in `MenuUI.cs`**

- **Line 182**:  
  Commented out this line to ensure that the configuration settings take priority.

- Added code to enforce that the variables retain the values specified in the configuration file.

---