### PR TITLE
Optifine like zoom

### DIFF
--- a/src/Cheats/MalumESP.cs
+++ b/src/Cheats/MalumESP.cs
@@ -28,6 +28,15 @@ public static class MalumESP
         return CheatToggles.fullBright || Camera.main.orthographicSize > 3f || Camera.main.gameObject.GetComponent<FollowerCamera>().Target != PlayerControl.LocalPlayer;
     }
 
+    public static void zoomToggle(HudManager hudManager)
+    {
+        // Funktion to zoom out 2 times
+        Camera.main.orthographicSize++;
+        hudManager.UICamera.orthographicSize++;
+        Camera.main.orthographicSize++;
+        hudManager.UICamera.orthographicSize++;
+    }
+
     public static void zoomOut(HudManager hudManager)
     {
         if(CheatToggles.zoomOut){

--- a/src/MalumMenu.cs
+++ b/src/MalumMenu.cs
@@ -27,6 +27,7 @@ public partial class MalumMenu : BasePlugin
     public static ConfigEntry<string> guestFriendCode;
     public static ConfigEntry<bool> guestMode;
     public static ConfigEntry<bool> noTelemetry;
+    public static ConfigEntry<string> ToggleZoom;
 
     public override void Load()
     {
@@ -71,6 +72,11 @@ public partial class MalumMenu : BasePlugin
                                 "NoTelemetry",
                                 true,
                                 "When enabled it will stop Among Us from collecting analytics of your games and sending them to Innersloth using Unity Analytics");
+
+        ToggleZoom = Config.Bind("MalumMenu.Cheats",
+                                "ToggleZoom",
+                                "c",
+                                "The keyboard key used to toggle the zoom hack on on press and off on release. List of supported keycodes: https://docs.unity3d.com/Packages/com.unity.tiny@0.16/api/Unity.Tiny.Input.KeyCode.html");
 
 
 

--- a/src/MalumMenu.cs
+++ b/src/MalumMenu.cs
@@ -7,7 +7,7 @@ using UnityEngine.Analytics;
 using System.Collections.Generic;
 using BepInEx.Configuration;
 using HarmonyLib;
-
+//update
 namespace MalumMenu;
 
 [BepInAutoPlugin]

--- a/src/MalumMenu.cs
+++ b/src/MalumMenu.cs
@@ -7,7 +7,7 @@ using UnityEngine.Analytics;
 using System.Collections.Generic;
 using BepInEx.Configuration;
 using HarmonyLib;
-//update
+
 namespace MalumMenu;
 
 [BepInAutoPlugin]

--- a/src/UI/MenuUI.cs
+++ b/src/UI/MenuUI.cs
@@ -153,14 +153,14 @@ public class MenuUI : MonoBehaviour
         if (Input.GetKeyDown(Utils.stringToKeycode(MalumMenu.ToggleZoom.Value)) && DestroyableSingleton<HudManager>.Instance.Chat.IsClosedOrClosing)
         { 
             // Toggle zoom hack with c key
-            CheatToggles.zoomOut = !CheatToggles.zoomOut; 
+            CheatToggles.zoomOut = true; 
 
             // Also zoom out 2 times for immediate use and easy usablity 
             MalumESP.zoomToggle(DestroyableSingleton<HudManager>.Instance);
         }
         else if (Input.GetKeyUp(Utils.stringToKeycode(MalumMenu.ToggleZoom.Value)) && DestroyableSingleton<HudManager>.Instance.Chat.IsClosedOrClosing)
         {
-            CheatToggles.zoomOut = !CheatToggles.zoomOut;
+            CheatToggles.zoomOut = false;
         }
 
         //Passive cheats are always on to avoid problems

--- a/src/UI/MenuUI.cs
+++ b/src/UI/MenuUI.cs
@@ -1,5 +1,7 @@
 using UnityEngine;
 using System.Collections.Generic;
+using System;
+using JetBrains.Annotations;
 
 namespace MalumMenu;
 public class MenuUI : MonoBehaviour
@@ -10,6 +12,7 @@ public class MenuUI : MonoBehaviour
     private Rect windowRect = new Rect(10, 10, 300, 500);
     private bool isGUIActive = false;
     private GUIStyle submenuButtonStyle;
+    
 
     // Create all groups (buttons) and their toggles on start
     private void Start()
@@ -145,6 +148,19 @@ public class MenuUI : MonoBehaviour
             //Also teleport the window to the mouse for immediate use
             Vector2 mousePosition = Input.mousePosition;
             windowRect.position = new Vector2(mousePosition.x, Screen.height - mousePosition.y);
+        }
+
+        if (Input.GetKeyDown(Utils.stringToKeycode(MalumMenu.ToggleZoom.Value)) && DestroyableSingleton<HudManager>.Instance.Chat.IsClosedOrClosing)
+        { 
+            // Toggle zoom hack with c key
+            CheatToggles.zoomOut = !CheatToggles.zoomOut; 
+
+            // Also zoom out 2 times for immediate use and easy usablity 
+            MalumESP.zoomToggle(DestroyableSingleton<HudManager>.Instance);
+        }
+        else if (Input.GetKeyUp(Utils.stringToKeycode(MalumMenu.ToggleZoom.Value)) && DestroyableSingleton<HudManager>.Instance.Chat.IsClosedOrClosing)
+        {
+            CheatToggles.zoomOut = !CheatToggles.zoomOut;
         }
 
         //Passive cheats are always on to avoid problems

--- a/start.bat
+++ b/start.bat
@@ -1,0 +1,17 @@
+@echo off
+REM Step 1: Build the project
+dotnet build
+
+REM Step 2: Navigate to the build output directory
+cd src\bin\Debug\net6.0
+
+REM Step 3: Move the DLL to the Among Us plugins directory
+move /Y "MalumMenu.dll" "D:\SteamLibrary\steamapps\common\Among Us\BepInEx\plugins"
+
+REM Optional: Print a message if the operation was successful
+if %errorlevel%==0 (
+    echo DLL successfully moved to Among Us plugins directory.
+) else (
+    echo Failed to move the DLL.
+)
+Pause Nul


### PR DESCRIPTION

This update introduces functionality to zoom out when the "C" key is pressed. The keybind can be adjusted in the config.

## Changelog

### `MalumMenu.cs`
- **Lines 30, 76-79:** Added a configuration entry for the zoom feature.

### `MenuUI.cs`
- **Lines 153-164:** Implemented functionality to zoom out when the keybind is pressed. The zoom will return to the original state when the key is released. This feature is disabled while the Among Us chat is open.

### `MalumESP.cs`
- **Lines 31-39:** Added functionality to zoom out twice.

