### PR TITLE
Update CheatToggles.cs

### DIFF
--- a/src/UI/CheatToggles.cs
+++ b/src/UI/CheatToggles.cs
@@ -60,6 +60,12 @@ namespace MalumMenu
         public static bool colorBasedTracers;
         public static bool distanceBasedTracers;
         
+        
+        
+        
+        
+        
+        
         //Ship
         public static bool closeMeeting;
         public static bool doorsSab;


### PR DESCRIPTION
Resolved issues with the main branch for panic made

#### **CheatToggles.cs**
  - Introduced a new category: `Other`.
  - Added a new public static toggle: `panicMode = false`.

#### **MenuUI.cs**
  - Implemented logic at line 140 to disable the GUI when `panicMode` is enabled.
  - Added a new group titled "Other" to the menu UI.
  - Included a cheat toggle for `Panic Mode` under the "Other" category.

#### **OtherPatches.cs**
  - At line 70, the displayed version changes to "Among Us Version" when `panicMode` is enabled, replacing the "Malum Menu Version".
  - At line 95, the text "MalumMenu by scp222thj" is hidden in-game when `panicMode` is active.

#### **MalumCheats.cs**
  - Added `PanicMode` logic at line 369:
    - Disables all cheats.
    - Sets `ModManager.Instance.ModStamp.enabled` to `false`, effectively hiding the mod stamp.

#### **Important Notice:**
- When `Panic Mode` is activated:
  - The "MalumMenu by scp222thj" text will be hidden.
  - Upon exiting the game, the "Malum Menu Version" will be replaced by the "Among Us Build Version".
  - The GUI cannot be reopened after it has been closed. 
  - The Modstamp will be hidden

This update adds a Panic feature to quickly disable cheats and remove mod indicators, to hide from screenshare.