### PR TITLE
Fix for new Among Us version

### DIFF
--- a/src/MalumMenu.cs
+++ b/src/MalumMenu.cs
@@ -15,8 +15,8 @@ namespace MalumMenu;
 public partial class MalumMenu : BasePlugin
 {
     public Harmony Harmony { get; } = new(Id);
-    public static string malumVersion = "2.5.0";
-    public static List<string> supportedAU = new List<string> { "2025.3.25" };
+    public static string malumVersion = "2.4.2";
+    public static List<string> supportedAU = new List<string> { "2025.3.25", "2025.3.31" };
     public static MenuUI menuUI;
     // public static ConsoleUI consoleUI;
     public static ConfigEntry<string> menuKeybind;

--- a/src/MalumMenu.cs
+++ b/src/MalumMenu.cs
@@ -15,8 +15,8 @@ namespace MalumMenu;
 public partial class MalumMenu : BasePlugin
 {
     public Harmony Harmony { get; } = new(Id);
-    public static string malumVersion = "2.4.2";
-    public static List<string> supportedAU = new List<string> { "2024.9.4" };
+    public static string malumVersion = "2.5.0";
+    public static List<string> supportedAU = new List<string> { "2025.3.25" };
     public static MenuUI menuUI;
     // public static ConsoleUI consoleUI;
     public static ConfigEntry<string> menuKeybind;

--- a/src/MalumMenu.csproj
+++ b/src/MalumMenu.csproj
@@ -15,7 +15,7 @@
 
     <ItemGroup>
         <PackageReference Include="BepInEx.Unity.IL2CPP" Version="6.0.0-be.662" Private="false" ExcludeAssets="runtime;native" />
-        <PackageReference Include="AmongUs.GameLibs.Steam" Version="2024.9.4" PrivateAssets="all" />
+        <PackageReference Include="AmongUs.GameLibs.Steam" Version="2025.3.25" PrivateAssets="all" />
 
         <PackageReference Include="BepInEx.AutoPlugin" Version="1.1.0" PrivateAssets="all" />
         <PackageReference Include="BepInEx.IL2CPP.MSBuild" Version="2.0.1" PrivateAssets="all" ExcludeAssets="runtime" />

--- a/src/Patches/OtherPatches.cs
+++ b/src/Patches/OtherPatches.cs
@@ -1,5 +1,6 @@
 using HarmonyLib;
 using AmongUs.Data;
+using AmongUs.Data.Player;
 using UnityEngine;
 using System;
 using System.Security.Cryptography;
@@ -146,16 +147,15 @@ public static class HatManager_Initialize
     }
 }
 
-[HarmonyPatch(typeof(StatsManager), nameof(StatsManager.BanMinutesLeft), MethodType.Getter)]
-public static class StatsManager_BanMinutesLeft_Getter
+[HarmonyPatch(typeof(PlayerBanData), nameof(PlayerBanData.BanMinutesLeft), MethodType.Getter)]
+public static class PlayerBanData_BanMinutesLeft_Getter
 {
     // Prefix patch of Getter method for StatsManager.BanMinutesLeft to remove disconnect penalty
-    public static void Postfix(StatsManager __instance, ref int __result)
+    public static void Postfix(PlayerBanData __instance, ref int __result)
     {
-        if (CheatToggles.avoidBans){
-            __instance.BanPoints = 0f; // Removes all BanPoints
-            __result = 0; // Removes all BanMinutes
-        }
+        if (!CheatToggles.avoidBans) return;
+        __instance.BanPoints = 0f; // Removes all BanPoints
+        __result = 0; // Removes all BanMinutes
     }
 }
 

--- a/src/Utilities/Utils.cs
+++ b/src/Utilities/Utils.cs
@@ -29,7 +29,7 @@ public static class Utils
     public static bool isNormalGame => GameOptionsManager.Instance.CurrentGameOptions.GameMode == GameModes.Normal;
     public static bool isHideNSeek => GameOptionsManager.Instance.CurrentGameOptions.GameMode == GameModes.HideNSeek;
     public static bool SkeldIsActive => (MapNames)GameOptionsManager.Instance.CurrentGameOptions.MapId == MapNames.Skeld;
-    public static bool MiraHQIsActive => (MapNames)GameOptionsManager.Instance.CurrentGameOptions.MapId == MapNames.Mira;
+    public static bool MiraHQIsActive => (MapNames)GameOptionsManager.Instance.CurrentGameOptions.MapId == MapNames.MiraHQ;
     public static bool PolusIsActive => (MapNames)GameOptionsManager.Instance.CurrentGameOptions.MapId == MapNames.Polus;
     public static bool DleksIsActive => (MapNames)GameOptionsManager.Instance.CurrentGameOptions.MapId == MapNames.Dleks;
     public static bool AirshipIsActive => (MapNames)GameOptionsManager.Instance.CurrentGameOptions.MapId == MapNames.Airship;


### PR DESCRIPTION
Among Us got 2 updates (v16.0.0 and v16.0.2) that broke MalumMenu.

This PR adds the latest game versions to the `supportedAU` list and updates two other things to make the menu work again.