### PR TITLE
Update Microsoft Store Installation Path

### DIFF
--- a/README.md
+++ b/README.md
@@ -68,7 +68,7 @@
     - **Steam:** Right-click Among Us in your Library → Click `Manage` → Click `Browse local files`.
     - **Epic Launcher:** Right-click Among Us in your Library → Click `Manage` → Click the folder icon in the `Installation` box.
     - **Itch.io:** Open the Itch.io app → Right-click Among Us in your Library → Click `Manage` → Click `Open folder in Explorer`.
-    - **Microsoft Store** Open the location where Among Us is installed (usually under `C:\XboxGames\Among Us\Content` or `C:\Program Files\WindowsApps` depending on your installation).
+    - **Microsoft Store:** Open the location where Among Us is installed (usually under `C:\XboxGames\Among Us\Content` or `C:\Program Files\WindowsApps` depending on your installation).
 
 4. Launch Among Us as you normally would. You should see a console window appear, installing the mod's requirements.
 


### PR DESCRIPTION
### What changed
Added the modern/new Microsoft store installation path to the README instructions for Microsoft Store users. 

### Why it was changed
The current README only points to the old `C:\Program Files\WindowsApps\` directory. However, the modern Microsoft Store defaults to installing games in `C:\XboxGames\Among Us\Content`. Adding this path helps players find their game files much easier without having to go through other folders.