### PR TITLE
Bump supported Among Us version from 2026.2.24 to 2026.3.17

### DIFF
--- a/src/MalumMenu.cs
+++ b/src/MalumMenu.cs
@@ -26,7 +26,7 @@ public partial class MalumMenu : BasePlugin
     public static ProtectUI protectUI;
 
     public static string malumVersion = "3.0.0";
-    public static List<string> supportedAU = new List<string> { "2026.3.17" };
+    public static List<string> supportedAU = new List<string> { "2026.2.24", "2026.3.17" };
 
     public static ConfigEntry<string> menuKeybind;
     public static ConfigEntry<string> menuHtmlColor;


### PR DESCRIPTION
Very small game update, basically no code changes. Didn't test every feature but there should be no issues at all.