### PR TITLE
Fix urgent issues with chat input

### DIFF
--- a/src/Patches/TextBoxTMPPatches.cs
+++ b/src/Patches/TextBoxTMPPatches.cs
@@ -41,7 +41,7 @@ public static class TextBoxTMP_IsCharAllowed
 {
     private static int _currentCharPos = 0;
 
-    // Prefix patch of TextBoxTMP.IsCharAllowed to allow all characters
+    // Prefix patch of TextBoxTMP.IsCharAllowed to unlock extra characters
     public static bool Prefix(TextBoxTMP __instance, ref bool __result)
     {
         // If user is writing through IME composition, then always allow the inputted characters
@@ -54,9 +54,6 @@ public static class TextBoxTMP_IsCharAllowed
             return false;
         }
 
-        // Reconstruct the string being processed by TextBoxTMP.SetText
-        // Each individual character in this string is being checked in a foreach loop
-
         // If the user pasted text, read from clipboard. Otherwise use typed input
         var input = Utils.isPastingInput ? GUIUtility.systemCopyBuffer : Input.inputString;
 
@@ -67,6 +64,8 @@ public static class TextBoxTMP_IsCharAllowed
             return false;
         }
 
+        // Reconstruct the full string being processed by TextBoxTMP.SetText
+
         string currentText = __instance.text ?? string.Empty;
 
         int caretPos = Mathf.Clamp(__instance.caretPos, 0, currentText.Length);
@@ -74,7 +73,7 @@ public static class TextBoxTMP_IsCharAllowed
         string text = currentText.Insert(caretPos, input);
 
         // Get character that is currently being checked by keeping track
-        // of each TextBoxTMP.IsCharAllowed call made within the foreach loop
+        // of each TextBoxTMP.IsCharAllowed call made within TextBoxTMP.SetText foreach loop
 
         _currentCharPos = Mathf.Clamp(_currentCharPos, 0, text.Length - 1);
 


### PR DESCRIPTION
Fix: Textbox input occasionally blocking
Fix: TextBoxTMP.SetText occasionally failing when called without pasted / typed input
Style: Improvements to comments