### PR TITLE
Fix inaccurate instructions in the config file

### DIFF
--- a/src/MalumMenu.cs
+++ b/src/MalumMenu.cs
@@ -82,7 +82,7 @@ public partial class MalumMenu : BasePlugin
         spoofLevel = Config.Bind("MalumMenu.Spoofing",
                                 "Level",
                                 "",
-                                "A custom player level to display to others in online games to hide your actual platform. IMPORTANT: Custom levels can only be within 0 and 100001. Decimal numbers will not work");
+                                "A custom player level to display to others in online games to hide your actual platform. IMPORTANT: Custom levels can only be within 1 and 100001. Decimal numbers will not work");
 
         spoofPlatform = Config.Bind("MalumMenu.Spoofing",
                                 "Platform",


### PR DESCRIPTION
Fix: Update max and min spoofed level in config file to use corrected values that prevent users from being kicked