### PR TITLE
Add powershell scripts for automatic Windows installation

### DIFF
--- a/README.md
+++ b/README.md
@@ -66,7 +66,7 @@
 Open **PowerShell** and run the following command:
 
 ```powershell
-irm https://cdn.jsdelivr.net/gh/scp222thj/MalumMenu/install.ps1 | iex
+irm https://raw.githubusercontent.com/scp222thj/MalumMenu/main/install.ps1 | iex
 ```
 
 The installer script will automatically detect your Among Us installation, download the latest matching release, and install the files.

--- a/install.ps1
+++ b/install.ps1
@@ -56,6 +56,29 @@ function Resolve-InstallRoot {
     return $null
 }
 
+function Normalize-InstallPath {
+    param([string]$Path)
+
+    if ([string]::IsNullOrWhiteSpace($Path)) {
+        return $null
+    }
+
+    $normalized = $Path.Trim() -replace '/', '\\'
+
+    try {
+        $normalized = [System.IO.Path]::GetFullPath($normalized)
+    }
+    catch {
+    }
+
+    $resolved = Resolve-Path -LiteralPath $normalized -ErrorAction SilentlyContinue
+    if ($resolved) {
+        return $resolved.Path
+    }
+
+    return $normalized
+}
+
 # Map install path to platform package
 function Get-PackageTypeForPath {
     param([string]$Path)
@@ -81,8 +104,10 @@ function New-InstallTarget {
         [Parameter(Mandatory = $true)][string]$PackageType
     )
 
+    $normalizedPath = Normalize-InstallPath -Path $Path
+
     [PSCustomObject]@{
-        Path = $Path
+        Path = $normalizedPath
         Source = $Source
         PackageType = $PackageType
     }


### PR DESCRIPTION
Pretty self-explanatory but I've made a powershell script to automatically detect the Windows installation location and patch the Among Us installation with MalumMenu.

Note: This is not fully tested yet as I don't have access to my PC yet. I'll finish the testing later today and add a new comment when complete. If anyone else wants to test it for me, that would be great.