### PR TITLE
(Possible) fix for black screen issue

### DIFF
--- a/src/Cheats/MalumCheats.cs
+++ b/src/Cheats/MalumCheats.cs
@@ -416,7 +416,7 @@ public static class MalumCheats
             CheatToggles.animEmptyGarbage = false;
         }
 
-        if (!(map is MapNames.MiraHQ or MapNames.Fungle))
+        if (map is not (MapNames.MiraHQ or MapNames.Fungle))
         {
             if (CheatToggles.animCamsInUse && !_isCamsAnimActive)
             {
@@ -437,7 +437,7 @@ public static class MalumCheats
         }
     }
 
-    public static void StopAllAnimationsCheats()
+    public static void StopShipAnimCheats()
     {
         CheatToggles.animShields = false;
         CheatToggles.animAsteroids = false;

--- a/src/UI/Windows/MenuUI.cs
+++ b/src/UI/Windows/MenuUI.cs
@@ -130,7 +130,7 @@ public class MenuUI : MonoBehaviour
             CheatToggles.spamOpenAllDoors = false;
             CheatToggles.mushSpore = false;
 
-            MalumCheats.StopAllAnimationsCheats();
+            MalumCheats.StopShipAnimCheats();
         }
 
         if(!Utils.isHost && !Utils.isFreePlay)

--- a/src/Utilities/Utils.cs
+++ b/src/Utilities/Utils.cs
@@ -324,21 +324,20 @@ public static class Utils
     // Returns current map ID if available
     public static byte GetCurrentMapID()
     {
+        // Works for the tutorial
         if (isFreePlay)
         {
-            // Works for the tutorial
             return (byte)AmongUsClient.Instance.TutorialMapId;
         }
-        else if (GameOptionsManager.Instance?.currentGameOptions != null)
+
+        // Works for local / online games
+        if (GameOptionsManager.Instance?.currentGameOptions != null)
         {
-            // Works for local / online games
             return GameOptionsManager.Instance.currentGameOptions.MapId;
         }
-        else
-        {
-            // Defaults to byte.MaxValue if the current map ID is unavailable
-            return byte.MaxValue;
-        }
+
+        // Defaults to byte.MaxValue if the current map ID is unavailable
+        return byte.MaxValue;
     }
 
     // Gets SystemType of the room the player is currently in


### PR DESCRIPTION
- **Fix**: Prevent black screen issue. 
  - User logs shown it being triggered right after a series of `NullReferenceException` within the `GetCurrentMapID` utility when used for Animations cheats. 
  - The utility and the cheat are therefore given basic error handling to prevent similar issues.
  - I wasn't able to fully test if this fixes the black screen issue, as I haven't encountered it myself. But this is still good to have.
