### PR TITLE
Fix and add back Open Config

### DIFF
--- a/src/MalumMenu.cs
+++ b/src/MalumMenu.cs
@@ -42,6 +42,7 @@ public partial class MalumMenu : BasePlugin
     public static ConfigEntry<string> guestFriendCode;
     public static ConfigEntry<bool> guestMode;
     public static ConfigEntry<bool> autoLoadProfile;
+    public static ConfigEntry<string> configEditor;
 
     public override void Load()
     {
@@ -68,6 +69,11 @@ public partial class MalumMenu : BasePlugin
                                 "AutoLoadProfile",
                                 false,
                                 "When enabled, your saved keybind and toggle profile will be automatically loaded at game startup");
+
+        configEditor = Config.Bind("MalumMenu.Config",
+                                "ConfigEditor",
+                                "notepad.exe",
+                                "The program used to open the config file when using the Open Config toggle. Can be any executable, but using a text editor is recommended");
 
         // GuestMode config settings are commented out as the cheats are broken in latest updates
 

--- a/src/UI/Windows/MenuUI.cs
+++ b/src/UI/Windows/MenuUI.cs
@@ -76,6 +76,12 @@ public class MenuUI : MonoBehaviour
         var stamp = ModManager.Instance.ModStamp;
         if (stamp) stamp.enabled = !(MalumMenu.inStealthMode || MalumMenu.isPanicked);
 
+        if (CheatToggles.openConfig)
+        {
+            Utils.OpenConfigFile();
+            CheatToggles.openConfig = false;
+        }
+
         if (CheatToggles.reloadConfig)
         {
             MalumMenu.Plugin.Config.Reload();

--- a/src/UI/Windows/Tabs/ConfigTab.cs
+++ b/src/UI/Windows/Tabs/ConfigTab.cs
@@ -17,13 +17,13 @@ public class ConfigTab : ITab
 
     private void DrawGeneral()
     {
-        // CheatToggles.openConfig = GUILayout.Toggle(CheatToggles.openConfig, " Open Config");
+        CheatToggles.openConfig = GUILayout.Toggle(CheatToggles.openConfig, " Open Config");
 
-        // if (CheatToggles.openConfig)
-        // {
-        //    Utils.OpenConfigFile();
-        //    CheatToggles.openConfig = false;
-        // }
+        if (CheatToggles.openConfig)
+        {
+           Utils.OpenConfigFile();
+           CheatToggles.openConfig = false;
+        }
 
         CheatToggles.reloadConfig = GUILayout.Toggle(CheatToggles.reloadConfig, " Reload Config");
 

--- a/src/UI/Windows/Tabs/ConfigTab.cs
+++ b/src/UI/Windows/Tabs/ConfigTab.cs
@@ -19,12 +19,6 @@ public class ConfigTab : ITab
     {
         CheatToggles.openConfig = GUILayout.Toggle(CheatToggles.openConfig, " Open Config");
 
-        if (CheatToggles.openConfig)
-        {
-           Utils.OpenConfigFile();
-           CheatToggles.openConfig = false;
-        }
-
         CheatToggles.reloadConfig = GUILayout.Toggle(CheatToggles.reloadConfig, " Reload Config");
 
         CheatToggles.saveProfile = GUILayout.Toggle(CheatToggles.saveProfile, " Save to Profile");

--- a/src/Utilities/Utils.cs
+++ b/src/Utilities/Utils.cs
@@ -599,26 +599,20 @@ public static class Utils
         return null;
     }
 
-    // Opens the config file in the default text editor (doesn't work on Linux with Proton)
+    // Opens the config file in the default text editor
     public static void OpenConfigFile()
     {
         var configFilePath = Path.Combine(Paths.ConfigPath, "MalumMenu.cfg");
 
         if (File.Exists(configFilePath))
         {
-            try
+            System.Diagnostics.Process.Start(new System.Diagnostics.ProcessStartInfo
             {
-                System.Diagnostics.Process.Start(new System.Diagnostics.ProcessStartInfo
-                {
-                    FileName = configFilePath,
-                    UseShellExecute = true,
-                    Verb = "edit"
-                });
-            }
-            catch (Exception ex)
-            {
-                MalumMenu.Log.LogError($"Failed to open configuration file: {ex.Message}. If you are on Linux, this is expected.");
-            }
+                FileName = "notepad.exe",
+                Arguments = configFilePath,
+                UseShellExecute = true
+                //Verb = "edit"
+            });
         }
         else
         {

--- a/src/Utilities/Utils.cs
+++ b/src/Utilities/Utils.cs
@@ -602,7 +602,7 @@ public static class Utils
     // Opens the config file in the default text editor
     public static void OpenConfigFile()
     {
-        var configFilePath = Path.Combine(Paths.ConfigPath, "MalumMenu.cfg");
+        var configFilePath = MalumMenu.Plugin.Config.ConfigFilePath;
 
         if (File.Exists(configFilePath))
         {

--- a/src/Utilities/Utils.cs
+++ b/src/Utilities/Utils.cs
@@ -608,7 +608,7 @@ public static class Utils
         {
             System.Diagnostics.Process.Start(new System.Diagnostics.ProcessStartInfo
             {
-                FileName = "notepad.exe",
+                FileName = MalumMenu.configEditor.Value,
                 Arguments = configFilePath,
                 UseShellExecute = true
                 //Verb = "edit"

--- a/src/Utilities/Utils.cs
+++ b/src/Utilities/Utils.cs
@@ -603,27 +603,35 @@ public static class Utils
     public static void OpenConfigFile()
     {
         var configFilePath = MalumMenu.Plugin.Config.ConfigFilePath;
+        var configEditor = MalumMenu.configEditor.Value;
 
-        if (File.Exists(configFilePath))
+        if (!string.IsNullOrWhiteSpace(configEditor))
         {
-            try
+            if (File.Exists(configFilePath))
             {
-                System.Diagnostics.Process.Start(new System.Diagnostics.ProcessStartInfo
+                try
                 {
-                    FileName = MalumMenu.configEditor.Value,
-                    Arguments = configFilePath,
-                    UseShellExecute = true
-                    //Verb = "edit"
-                });
+                    System.Diagnostics.Process.Start(new System.Diagnostics.ProcessStartInfo
+                    {
+                        FileName = configEditor,
+                        Arguments = configFilePath,
+                        UseShellExecute = true
+                        //Verb = "edit"
+                    });
+                }
+                catch (Exception ex)
+                {
+                    MalumMenu.Log.LogError(ex.Message);
+                }
             }
-            catch (Exception ex)
+            else
             {
-                MalumMenu.Log.LogError(ex.Message);
+                MalumMenu.Log.LogError("Configuration file does not exist");
             }
         }
         else
         {
-            MalumMenu.Log.LogError("Configuration file does not exist");
+            MalumMenu.Log.LogError("Configuration editor not specified");
         }
     }
 

--- a/src/Utilities/Utils.cs
+++ b/src/Utilities/Utils.cs
@@ -606,13 +606,20 @@ public static class Utils
 
         if (File.Exists(configFilePath))
         {
-            System.Diagnostics.Process.Start(new System.Diagnostics.ProcessStartInfo
+            try
             {
-                FileName = MalumMenu.configEditor.Value,
-                Arguments = configFilePath,
-                UseShellExecute = true
-                //Verb = "edit"
-            });
+                System.Diagnostics.Process.Start(new System.Diagnostics.ProcessStartInfo
+                {
+                    FileName = MalumMenu.configEditor.Value,
+                    Arguments = configFilePath,
+                    UseShellExecute = true
+                    //Verb = "edit"
+                });
+            }
+            catch (Exception ex)
+            {
+                MalumMenu.Log.LogError(ex.Message);
+            }
         }
         else
         {


### PR DESCRIPTION
Enables the previously commented out "Open Config" toggle button (Config Tab)

This PR fixes two different issues with `Utils.OpenConfigFile`:
- "Open Config" not working at all for Linux users
- "Open Config" not working for people who don't have a default application set for .cfg files

changes verified and tested on both linux and windows machine