### PR TITLE
Changes to UI configuration

### DIFF
--- a/src/MalumMenu.cs
+++ b/src/MalumMenu.cs
@@ -35,6 +35,7 @@ public partial class MalumMenu : BasePlugin
     public static ConfigEntry<string> menuKeybind;
     public static ConfigEntry<string> menuHtmlColor;
     public static ConfigEntry<bool> menuOpenOnMouse;
+    public static ConfigEntry<bool> menuKeepSubwindowsOpen;
     public static ConfigEntry<string> spoofLevel;
     public static ConfigEntry<string> spoofPlatform;
     public static ConfigEntry<bool> spoofDeviceId;
@@ -63,6 +64,11 @@ public partial class MalumMenu : BasePlugin
                                 "OpenOnMouse",
                                 false,
                                 "When enabled, the MalumMenu GUI will always be opened at the current mouse position");
+
+        menuKeepSubwindowsOpen = Config.Bind("MalumMenu.GUI",
+                                "KeepSubwindowsOpen",
+                                false,
+                                "When enabled, closing the MalumMenu GUI will not automatically close its subwindows");
 
         autoLoadProfile = Config.Bind("MalumMenu.Profile",
                                 "AutoLoadProfile",

--- a/src/MalumMenu.cs
+++ b/src/MalumMenu.cs
@@ -61,7 +61,7 @@ public partial class MalumMenu : BasePlugin
 
         menuOpenOnMouse = Config.Bind("MalumMenu.GUI",
                                 "OpenOnMouse",
-                                true,
+                                false,
                                 "When enabled, the MalumMenu GUI will always be opened at the current mouse position");
 
         autoLoadProfile = Config.Bind("MalumMenu.Profile",

--- a/src/UI/Windows/ConsoleUI.cs
+++ b/src/UI/Windows/ConsoleUI.cs
@@ -27,7 +27,7 @@ public class ConsoleUI : MonoBehaviour
 
     private void OnGUI()
     {
-        if (!CheatToggles.showConsole || !MenuUI.isGUIActive || MalumMenu.isPanicked) return;
+        if (!CheatToggles.showConsole || !(MenuUI.isGUIActive || MalumMenu.menuKeepSubwindowsOpen.Value) || MalumMenu.isPanicked) return;
 
         _logStyle ??= new GUIStyle(GUI.skin.label)
         {

--- a/src/UI/Windows/DoorsUI.cs
+++ b/src/UI/Windows/DoorsUI.cs
@@ -11,7 +11,7 @@ public class DoorsUI : MonoBehaviour
 
     private void OnGUI()
     {
-        if (!CheatToggles.showDoorsMenu || !MenuUI.isGUIActive || MalumMenu.isPanicked) return;
+        if (!CheatToggles.showDoorsMenu || !(MenuUI.isGUIActive || MalumMenu.menuKeepSubwindowsOpen.Value) || MalumMenu.isPanicked) return;
 
         UIHelpers.ApplyUIColor();
 

--- a/src/UI/Windows/ProtectUI.cs
+++ b/src/UI/Windows/ProtectUI.cs
@@ -12,7 +12,7 @@ public class ProtectUI : MonoBehaviour
 
     private void OnGUI()
     {
-        if (!CheatToggles.showProtectMenu || !MenuUI.isGUIActive || MalumMenu.isPanicked) return;
+        if (!CheatToggles.showProtectMenu || !(MenuUI.isGUIActive || MalumMenu.menuKeepSubwindowsOpen.Value) || MalumMenu.isPanicked) return;
 
         UIHelpers.ApplyUIColor();
 

--- a/src/UI/Windows/RolesUI.cs
+++ b/src/UI/Windows/RolesUI.cs
@@ -9,7 +9,7 @@ public class RolesUI : MonoBehaviour
 
     private void OnGUI()
     {
-        if (!CheatToggles.showRolesMenu || !MenuUI.isGUIActive || MalumMenu.isPanicked) return;
+        if (!CheatToggles.showRolesMenu || !(MenuUI.isGUIActive || MalumMenu.menuKeepSubwindowsOpen.Value) || MalumMenu.isPanicked) return;
 
         UIHelpers.ApplyUIColor();
 

--- a/src/UI/Windows/TasksUI.cs
+++ b/src/UI/Windows/TasksUI.cs
@@ -13,7 +13,7 @@ public class TasksUI : MonoBehaviour
 
     private void OnGUI()
     {
-        if (!CheatToggles.showTasksMenu || !MenuUI.isGUIActive || MalumMenu.isPanicked) return;
+        if (!CheatToggles.showTasksMenu || !(MenuUI.isGUIActive || MalumMenu.menuKeepSubwindowsOpen.Value) || MalumMenu.isPanicked) return;
 
         _playerHeaderStyle ??= new GUIStyle(GUI.skin.button)
         {


### PR DESCRIPTION
- **Feat**: Set OpenOnMouse config as disabled by default.
- **Feat**: Add KeepSubwindowsOpen config. When enabled, closing the MalumMenu GUI will not automatically close its subwindows.