### PR TITLE
Make UI windows centered by default when opened

### DIFF
--- a/src/UI/Windows/ConsoleUI.cs
+++ b/src/UI/Windows/ConsoleUI.cs
@@ -6,23 +6,24 @@ namespace MalumMenu;
 
 public class ConsoleUI : MonoBehaviour
 {
+    public static int windowHeight = 350;
+    public static int windowWidth = 550;
+    private Rect _windowRect;
+
+    private GUIStyle _logStyle;
     private static Vector2 _scrollPosition = Vector2.zero;
     private static List<string> _logEntries = new();
     private const int MaxLogEntries = 300;
-    private Rect _windowRect = new(320, 10, 550, 350);
-    private GUIStyle _logStyle;
 
-    public static void Log(string message)
+    private void Start()
     {
-        if (_logEntries.Count >= MaxLogEntries) // Limit the number of logs to keep memory usage in check
-        {
-            _logEntries.RemoveAt(0); // Remove the oldest log entry
-        }
-
-        _logEntries.Add(message);
-
-        // Scroll to the bottom
-        _scrollPosition.y = float.MaxValue;
+        // Instantiate 2D area of ConsoleUI
+        _windowRect = new(
+            Screen.width / 2f - windowWidth / 2f,
+            Screen.height / 2f - windowHeight / 2f,
+            windowWidth,
+            windowHeight
+        );
     }
 
     private void OnGUI()
@@ -69,5 +70,18 @@ public class ConsoleUI : MonoBehaviour
         GUILayout.EndHorizontal();
 
         GUI.DragWindow();
+    }
+
+    public static void Log(string message)
+    {
+        if (_logEntries.Count >= MaxLogEntries) // Limit the number of logs to keep memory usage in check
+        {
+            _logEntries.RemoveAt(0); // Remove the oldest log entry
+        }
+
+        _logEntries.Add(message);
+
+        // Scroll to the bottom
+        _scrollPosition.y = float.MaxValue;
     }
 }

--- a/src/UI/Windows/DoorsUI.cs
+++ b/src/UI/Windows/DoorsUI.cs
@@ -5,9 +5,23 @@ namespace MalumMenu;
 
 public class DoorsUI : MonoBehaviour
 {
-    private Rect _windowRect = new(320, 10, 480, 270);
+    public static int windowHeight = 270;
+    public static int windowWidth = 480;
+    private Rect _windowRect;
+
     private List<SystemTypes> _doorsToSpamOpen = new();
     private List<SystemTypes> _doorsToSpamClose = new();
+
+    private void Start()
+    {
+        // Instantiate 2D area of DoorsUI
+        _windowRect = new(
+            Screen.width / 2f - windowWidth / 2f,
+            Screen.height / 2f - windowHeight / 2f,
+            windowWidth,
+            windowHeight
+        );
+    }
 
     private void OnGUI()
     {

--- a/src/UI/Windows/MenuUI.cs
+++ b/src/UI/Windows/MenuUI.cs
@@ -8,17 +8,16 @@ public class MenuUI : MonoBehaviour
 {
     public static int windowHeight = 550;
     public static int windowWidth = 700;
+    private Rect _windowRect;
 
-    private List<ITab> _tabs = new();
-    private Rect _windowRect = new(10, 10, windowWidth, windowHeight);
     public static bool isGUIActive = false;
+    private List<ITab> _tabs = new();
     private int _selectedTab;
-
     public static float hue; // For RGB mode
 
-    // Add all tabs on start
     private void Start()
     {
+        // Add all tabs on start
         _tabs.Add(new MovementTab());
         _tabs.Add(new ESPTab());
         _tabs.Add(new RolesTab());
@@ -30,6 +29,14 @@ public class MenuUI : MonoBehaviour
         _tabs.Add(new PassiveTab());
         _tabs.Add(new ModesTab());
         _tabs.Add(new ConfigTab());
+
+        // Instantiate 2D area of MenuUI
+        _windowRect = new(
+            Screen.width / 2f - windowWidth / 2f,
+            Screen.height / 2f - windowHeight / 2f,
+            windowWidth,
+            windowHeight
+        );
     }
 
     public void InitStyles()

--- a/src/UI/Windows/ProtectUI.cs
+++ b/src/UI/Windows/ProtectUI.cs
@@ -5,10 +5,24 @@ namespace MalumMenu;
 
 public class ProtectUI : MonoBehaviour
 {
+    public static int windowHeight = 300;
+    public static int windowWidth = 500;
+    private Rect _windowRect;
+
     private Vector2 _scrollPosition = Vector2.zero;
-    private Rect _windowRect = new(320, 10, 500, 300);
     public static List<PlayerControl> playersToProtect = new();
     private bool _keepEveryoneProtected;
+
+    private void Start()
+    {
+        // Instantiate 2D area of ProtectUI
+        _windowRect = new(
+            Screen.width / 2f - windowWidth / 2f,
+            Screen.height / 2f - windowHeight / 2f,
+            windowWidth,
+            windowHeight
+        );
+    }
 
     private void OnGUI()
     {

--- a/src/UI/Windows/RolesUI.cs
+++ b/src/UI/Windows/RolesUI.cs
@@ -4,8 +4,22 @@ namespace MalumMenu;
 
 public class RolesUI : MonoBehaviour
 {
+    public static int windowHeight = 100;
+    public static int windowWidth = 450;
+    private Rect _windowRect;
+
     private Vector2 _scrollPosition = Vector2.zero;
-    private Rect _windowRect = new(320, 10, 450, 100);
+
+    private void Start()
+    {
+        // Instantiate 2D area of RolesUI
+        _windowRect = new(
+            Screen.width / 2f - windowWidth / 2f,
+            Screen.height / 2f - windowHeight / 2f,
+            windowWidth,
+            windowHeight
+        );
+    }
 
     private void OnGUI()
     {

--- a/src/UI/Windows/TasksUI.cs
+++ b/src/UI/Windows/TasksUI.cs
@@ -5,11 +5,25 @@ namespace MalumMenu;
 
 public class TasksUI : MonoBehaviour
 {
+    public static int windowHeight = 300;
+    public static int windowWidth = 500;
+    private Rect _windowRect;
+
     private Vector2 _scrollPosition = Vector2.zero;
-    private Rect _windowRect = new(320, 10, 500, 300);
     private GUIStyle _playerHeaderStyle;
     private Il2CppSystem.Text.StringBuilder _tasksString = new();
     private readonly System.Collections.Generic.Dictionary<string, bool> _expandedPlayers = new();
+
+    private void Start()
+    {
+        // Instantiate 2D area of TasksUI
+        _windowRect = new(
+            Screen.width / 2f - windowWidth / 2f,
+            Screen.height / 2f - windowHeight / 2f,
+            windowWidth,
+            windowHeight
+        );
+    }
 
     private void OnGUI()
     {


### PR DESCRIPTION
- **Feat**: Make UI windows centered by default when first opened
  - Since now OpenOnMouse is disabled by default, this should be good to ensure initial position is predictable and consistent for all windows and always compatible with / adapted to different screen sizes.