### PR TITLE
v3.1.0 Release

### DIFF
--- a/README.md
+++ b/README.md
@@ -199,6 +199,8 @@ Here are some other useful resources:
 
 # ⚠️ Disclaimer
 
-This mod is not affiliated with Among Us or Innersloth LLC, and the content contained therein is not endorsed or otherwise sponsored by Innersloth LLC. Portions of the materials contained herein are property of Innersloth LLC.
+This mod is not affiliated with Among Us or Innersloth LLC, and the content contained therein is not endorsed or otherwise sponsored by Innersloth LLC. Portions of the materials contained herein are property of Innersloth LLC. © Innersloth LLC.
+
+This mod is not intended to be used in any manner that interferes with Innersloth's services, Innersloth's operation of Among Us, the integrity or availability of the game, or the normal gameplay experience of other players. The creator does not endorse, encourage, or condone using this mod to disrupt games, negatively affect other users, bypass rules or protections, or gain an unfair advantage in any setting where such use is prohibited. Any misuse is solely the responsibility of the user.
 
 Usage of this mod can violate the terms of service of Among Us, which may lead to punitive action including temporary or permanent bans from the game. The creator is not responsible for any consequences you may face due to usage. Use at your own risk.

--- a/README.md
+++ b/README.md
@@ -39,6 +39,7 @@
 
 | Mod Version| Among Us - Version | Link |
 |----------|-------------|-----------------|
+| v3.1.0 | 17.3 ( 2026.3.31 ) | [Download](https://github.com/scp222thj/MalumMenu/releases/tag/v3.1.0) |
 | v3.0.2 | 17.2.2 ( 2026.3.17 )<br>17.2.1 ( 2026.2.24 ) | [Download](https://github.com/scp222thj/MalumMenu/releases/tag/v3.0.2) |
 | v3.0.1 | 17.2.2 ( 2026.3.17 )<br>17.2.1 ( 2026.2.24 ) | [Download](https://github.com/scp222thj/MalumMenu/releases/tag/v3.0.1) |
 | v3.0.0 | 17.2.1 ( 2026.2.24 ) | [Download](https://github.com/scp222thj/MalumMenu/releases/tag/v3.0.0) |
@@ -134,7 +135,7 @@ Click to expand each topic
 
 <summary><h2>❗ I'm having issues installing MalumMenu</h2></summary>
 
-First of all, make sure you are running the most recent version of Among Us (`17.2.2` / `2026.3.17` OR `17.2.1` / `2026.2.24`) with the most recent version of MalumMenu (`v3.0.2`).
+First of all, make sure you are running the most recent version of Among Us (`17.3` / `2026.3.31`) with the most recent version of MalumMenu (`v3.1.0`).
 
 Also, check if your platform is officially supported:
 

--- a/src/Cheats/MalumPPMCheats.cs
+++ b/src/Cheats/MalumPPMCheats.cs
@@ -14,7 +14,7 @@ public static class MalumPPMCheats
     private static bool _teleportPlayerActive;
     private static bool _reportBodyActive;
     private static bool _ejectPlayerActive;
-    private static bool _changeRoleActive;
+    private static bool _setFakeRoleActive;
     private static bool _setFakeAliveActive;
     private static bool _forceRoleActive;
     private static RoleTypes? _oldRole = null;
@@ -238,19 +238,19 @@ public static class MalumPPMCheats
         }
     }
 
-    public static void ChangeRolePPM()
+    public static void SetFakeRolePPM()
     {
         if (CheatToggles.setFakeRole)
         {
 
-            if (!_changeRoleActive)
+            if (!_setFakeRoleActive)
             {
 
                 // Close any player pick menus already open & their cheats
                 if (PlayerPickMenu.playerpickMenu != null)
                 {
                     PlayerPickMenu.playerpickMenu.Close();
-                    CheatToggles.DisablePPMCheats("changeRole");
+                    CheatToggles.DisablePPMCheats("setFakeRole");
                 }
 
                 List<NetworkedPlayerInfo> playerDataList = new List<NetworkedPlayerInfo>();
@@ -293,7 +293,7 @@ public static class MalumPPMCheats
                 // Player pick menu made for changing your roles with a custom choice list
                 PlayerPickMenu.OpenPlayerPickMenu(playerDataList, (Action) (() =>
                 {
-                    // Log the originally assigned role before it gets changed by changeRole cheat
+                    // Log the originally assigned role before it gets changed by setFakeRole cheat
                     if (!Utils.isLobby && !Utils.isFreePlay && _oldRole == null)
                     {
                         _oldRole = PlayerControl.LocalPlayer.Data.RoleType;
@@ -330,7 +330,7 @@ public static class MalumPPMCheats
                     }
                 }));
 
-                _changeRoleActive = true;
+                _setFakeRoleActive = true;
             }
 
             // Deactivate cheat if menu is closed
@@ -342,9 +342,9 @@ public static class MalumPPMCheats
         }
         else
         {
-            if (_changeRoleActive)
+            if (_setFakeRoleActive)
             {
-                _changeRoleActive = false;
+                _setFakeRoleActive = false;
             }
         }
     }

--- a/src/MalumMenu.cs
+++ b/src/MalumMenu.cs
@@ -186,10 +186,10 @@ public partial class MalumMenu : BasePlugin
         menuUI = AddComponent<MenuUI>();
         consoleUI = AddComponent<ConsoleUI>();
         overloadUI = AddComponent<OverloadUI>();
-        rolesUI = AddComponent<RolesUI>();
         doorsUI = AddComponent<DoorsUI>();
         tasksUI = AddComponent<TasksUI>();
         protectUI = AddComponent<ProtectUI>();
+        // rolesUI = AddComponent<RolesUI>();
 
         // Components
         keybindListener = AddComponent<KeybindListener>();

--- a/src/MalumMenu.cs
+++ b/src/MalumMenu.cs
@@ -29,7 +29,7 @@ public partial class MalumMenu : BasePlugin
     public static KeybindListener keybindListener;
 
     public static string malumVersion = "3.1.0";
-    public static List<string> supportedAU = new List<string> { "2026.2.24", "2026.3.17", "2026.3.31" };
+    public static List<string> supportedAU = new List<string> { "2026.3.31" };
     public static bool isPanicked = false;
     public static bool inStealthMode = false;
 

--- a/src/MalumMenu.cs
+++ b/src/MalumMenu.cs
@@ -28,7 +28,7 @@ public partial class MalumMenu : BasePlugin
     public static ProtectUI protectUI;
     public static KeybindListener keybindListener;
 
-    public static string malumVersion = "3.0.2";
+    public static string malumVersion = "3.1.0";
     public static List<string> supportedAU = new List<string> { "2026.2.24", "2026.3.17", "2026.3.31" };
     public static bool isPanicked = false;
     public static bool inStealthMode = false;

--- a/src/Patches/PlayerPhysicsPatches.cs
+++ b/src/Patches/PlayerPhysicsPatches.cs
@@ -28,8 +28,8 @@ public static class PlayerPhysics_LateUpdate
         MalumPPMCheats.KillPlayerPPM();
         MalumPPMCheats.TelekillPlayerPPM();
         MalumPPMCheats.TeleportPlayerPPM();
-        MalumPPMCheats.ChangeRolePPM();
         MalumPPMCheats.ForceRolePPM();
+        MalumPPMCheats.SetFakeRolePPM();
         MalumPPMCheats.SetFakeAlivePPM();
 
         // This check ensures there is only one run per frame

--- a/src/Patches/PlayerPhysicsPatches.cs
+++ b/src/Patches/PlayerPhysicsPatches.cs
@@ -28,9 +28,9 @@ public static class PlayerPhysics_LateUpdate
         MalumPPMCheats.KillPlayerPPM();
         MalumPPMCheats.TelekillPlayerPPM();
         MalumPPMCheats.TeleportPlayerPPM();
-        MalumPPMCheats.ForceRolePPM();
         MalumPPMCheats.SetFakeRolePPM();
         MalumPPMCheats.SetFakeAlivePPM();
+        // MalumPPMCheats.ForceRolePPM();
 
         // This check ensures there is only one run per frame
         // so that OverloadHandler._timer progression remains accurate

--- a/src/UI/Elements/CheatToggles.cs
+++ b/src/UI/Elements/CheatToggles.cs
@@ -203,7 +203,7 @@ public struct CheatToggles
         killPlayer = variableToKeep == "killPlayer" && killPlayer;
         telekillPlayer = variableToKeep == "telekillPlayer" && telekillPlayer;
         spectate = variableToKeep == "spectate" && spectate;
-        setFakeRole = variableToKeep == "changeRole" && setFakeRole;
+        setFakeRole = variableToKeep == "setFakeRole" && setFakeRole;
         setFakeAlive = variableToKeep == "setFakeAlive" && setFakeAlive;
         forceRole = variableToKeep == "forceRole" && forceRole;
         teleportPlayer = variableToKeep == "teleportPlayer" && teleportPlayer;

--- a/src/Utilities/Utils.cs
+++ b/src/Utilities/Utils.cs
@@ -709,10 +709,10 @@ public static class Utils
 
         UnityEngine.Object.Destroy(MalumMenu.consoleUI);
         UnityEngine.Object.Destroy(MalumMenu.overloadUI);
-        UnityEngine.Object.Destroy(MalumMenu.rolesUI);
         UnityEngine.Object.Destroy(MalumMenu.doorsUI);
         UnityEngine.Object.Destroy(MalumMenu.tasksUI);
         UnityEngine.Object.Destroy(MalumMenu.protectUI);
+        // UnityEngine.Object.Destroy(MalumMenu.rolesUI);
 
         UnityEngine.Object.Destroy(MalumMenu.keybindListener);
 


### PR DESCRIPTION
- **Chore**: Bump Malum version from v3.0.2 to v3.1.0
- **Chore**: Limit supported AU versions to only 2026.3.31
  - Changes introduced in PR #536 only work starting with that version
- **Docs**: Add v3.1.0 to README

I took the opportunity to also include some minor changes in this PR I've been meaning to do:
- **Docs**: Extend the disclaimer in README to cover fair use
- **Style**: Rename changeRole to setFakeRole across the whole codebase
- **Refactor**: Fully disable unused ForceRole feature 
  - No use in keeping the UI as a component and the checks running when all toggles to use it are gone
  - It will be brought back in a future update though, so it's a temporary removal