### PR TITLE
feat: Add Host-Only Set All Same Color and Any-One Send Private Message

### DIFF
--- a/src/Cheats/MalumNewCheats.cs
+++ b/src/Cheats/MalumNewCheats.cs
@@ -1,0 +1,194 @@
+using Il2CppSystem.Collections.Generic;
+using System;
+using UnityEngine;
+using Hazel;
+
+namespace MalumMenu;
+
+/// <summary>
+/// Contains implementations for the new cheat features:
+/// - Set All Same Color (Host-Only): Sets all players to the same selected color
+/// - Send Private Message (Any-One): Sends a chat message visible only to selected players
+/// </summary>
+public static class MalumNewCheats
+{
+    private static bool _setAllSameColorActive;
+    private static bool _sendPrivateMessageActive;
+
+    // Among Us color names matching the color IDs
+    public static readonly string[] ColorNames = new string[]
+    {
+        "Red", "Blue", "Green", "Pink", "Orange",
+        "Yellow", "Black", "White", "Purple", "Brown",
+        "Cyan", "Lime", "Maroon", "Rose", "Banana",
+        "Gray", "Tan", "Coral", "Olive", "Turquoise"
+    };
+
+    /// <summary>
+    /// Host-Only: Opens a PPM to select a color, then sets ALL players to that color.
+    /// Uses RPC SetColor (0x08) sent from each player's PlayerControl NetId.
+    /// Only the host can do this because SetColor is a host-authority RPC.
+    /// </summary>
+    public static void SetAllSameColorPPM()
+    {
+        if (CheatToggles.setAllSameColor)
+        {
+            if (!_setAllSameColorActive)
+            {
+                // Close any player pick menus already open & their cheats
+                if (PlayerPickMenu.playerpickMenu != null)
+                {
+                    PlayerPickMenu.playerpickMenu.Close();
+                    CheatToggles.DisablePPMCheats("setAllSameColor");
+                }
+
+                List<NetworkedPlayerInfo> colorChoices = new List<NetworkedPlayerInfo>();
+
+                // Create a PPM entry for each available color
+                for (int i = 0; i < ColorNames.Length && i < Palette.PlayerColors.Count; i++)
+                {
+                    var outfit = new NetworkedPlayerInfo.PlayerOutfit()
+                    {
+                        ColorId = i
+                    };
+                    colorChoices.Add(PlayerPickMenu.CustomPPMChoice(ColorNames[i], outfit));
+                }
+
+                // Player pick menu to choose a color and set all players to it
+                PlayerPickMenu.OpenPlayerPickMenu(colorChoices, (Action)(() =>
+                {
+                    int colorId = PlayerPickMenu.targetPlayerData.DefaultOutfit.ColorId;
+
+                    // Set every player's color to the selected color using RPC
+                    foreach (var player in PlayerControl.AllPlayerControls)
+                    {
+                        // Use RpcSetColor which is the proper host-authority method
+                        player.RpcSetColor((byte)colorId);
+                    }
+                }));
+
+                _setAllSameColorActive = true;
+            }
+
+            // Deactivate cheat if menu is closed
+            if (PlayerPickMenu.playerpickMenu == null)
+            {
+                CheatToggles.setAllSameColor = false;
+            }
+        }
+        else if (_setAllSameColorActive)
+        {
+            _setAllSameColorActive = false;
+        }
+    }
+
+    /// <summary>
+    /// Any-One: Opens a PPM to select a target player, then activates private message mode.
+    /// Only stores the target's player ID (byte) and name (string) — never IL2CPP object references.
+    /// After selection, the in-game chat opens and the next message sent is intercepted
+    /// by the ChatController patch and sent as a targeted RPC.
+    /// </summary>
+    public static void SendPrivateMessagePPM()
+    {
+        if (CheatToggles.sendPrivateMessage)
+        {
+            if (!_sendPrivateMessageActive)
+            {
+                // Close any player pick menus already open & their cheats
+                if (PlayerPickMenu.playerpickMenu != null)
+                {
+                    PlayerPickMenu.playerpickMenu.Close();
+                    CheatToggles.DisablePPMCheats("sendPrivateMessage");
+                }
+
+                List<NetworkedPlayerInfo> playerDataList = new List<NetworkedPlayerInfo>();
+
+                // Add all players except LocalPlayer to the selection
+                foreach (var player in PlayerControl.AllPlayerControls)
+                {
+                    if (!player.AmOwner && player.Data != null && !player.Data.Disconnected)
+                    {
+                        playerDataList.Add(player.Data);
+                    }
+                }
+
+                // Player pick menu to choose the target for the private message
+                // IMPORTANT: Only extract primitive values from the PPM result, never store the IL2CPP object
+                PlayerPickMenu.OpenPlayerPickMenu(playerDataList, (Action)(() =>
+                {
+                    byte playerId = PlayerPickMenu.targetPlayerData.PlayerId;
+                    string playerName = PlayerPickMenu.targetPlayerData.PlayerName;
+
+                    // Activate private mode with safe primitive values only
+                    PrivateMessageState.Activate(playerId, playerName);
+                }));
+
+                _sendPrivateMessageActive = true;
+            }
+
+            // Deactivate cheat if menu is closed
+            if (PlayerPickMenu.playerpickMenu == null)
+            {
+                CheatToggles.sendPrivateMessage = false;
+            }
+        }
+        else if (_sendPrivateMessageActive)
+        {
+            _sendPrivateMessageActive = false;
+        }
+    }
+
+    /// <summary>
+    /// Sends a chat message that only the specified target player can see.
+    /// Looks up the player fresh by ID to avoid dangling IL2CPP pointers.
+    /// Uses StartRpcImmediately with the target's client ID to send a targeted SendChat RPC.
+    /// </summary>
+    public static void SendPrivateChat(string message, byte targetPlayerId, string targetName)
+    {
+        if (string.IsNullOrWhiteSpace(message)) return;
+
+        // Look up the target player fresh by ID — never use cached IL2CPP references
+        PlayerControl targetPlayer = null;
+        try
+        {
+            foreach (var player in PlayerControl.AllPlayerControls)
+            {
+                if (player != null && player.PlayerId == targetPlayerId)
+                {
+                    targetPlayer = player;
+                    break;
+                }
+            }
+        }
+        catch { return; }
+
+        if (targetPlayer == null) return;
+
+        try
+        {
+            // Get the target's client ID
+            int targetClientId = AmongUsClient.Instance.GetClientIdFromCharacter(targetPlayer);
+
+            // Send SendChat RPC (0x0d) only to the targeted player
+            MessageWriter writer = AmongUsClient.Instance.StartRpcImmediately(
+                PlayerControl.LocalPlayer.NetId,
+                (byte)RpcCalls.SendChat,
+                SendOption.Reliable,
+                targetClientId
+            );
+            writer.Write(message);
+            AmongUsClient.Instance.FinishRpcImmediately(writer);
+
+            // Also show it locally in our own chat (so we can see what we sent)
+            if (DestroyableSingleton<HudManager>.Instance?.Chat != null)
+            {
+                DestroyableSingleton<HudManager>.Instance.Chat.AddChat(
+                    PlayerControl.LocalPlayer,
+                    $"<color=#ff69b4>[PM > {targetName}]</color> {message}",
+                    false
+                );
+            }
+        }
+        catch { }
+    }
+}

--- a/src/Patches/ChatControllerPatches.cs
+++ b/src/Patches/ChatControllerPatches.cs
@@ -109,13 +109,31 @@ public static class ChatController_SendChat
 [HarmonyPatch(typeof(ChatController), nameof(ChatController.SendFreeChat))]
 public static class ChatController_SendFreeChat
 {
-    // Prefix patch of ChatController.SendFreeChat to allow sending URLs without being censored
+    // Prefix patch of ChatController.SendFreeChat
+    // Handles both private message interception AND URL bypass
     public static bool Prefix(ChatController __instance)
     {
-		// Only works if CheatSettings.bypassUrlBlock is enabled
-        if (!CheatToggles.bypassUrlBlock) return true;
-
         string text = __instance.freeChatField.Text;
+
+        // Private message mode: intercept and send only to target
+        if (PrivateMessageState.isPrivateMode)
+        {
+            if (!string.IsNullOrWhiteSpace(text))
+            {
+                MalumNewCheats.SendPrivateChat(text, PrivateMessageState.targetPlayerId, PrivateMessageState.targetName);
+            }
+
+            // Clear the chat field manually
+            __instance.freeChatField.Clear();
+
+            // Exit private mode after sending
+            PrivateMessageState.Cancel();
+
+            return false; // Skip normal send
+        }
+
+        // Original bypass URL block logic
+        if (!CheatToggles.bypassUrlBlock) return true;
 
         // Replace periods in URLs and email addresses with commas to avoid censorship
         string modifiedText = CensorUrlsAndEmails(text);

--- a/src/Patches/ShipStatusPatches.cs
+++ b/src/Patches/ShipStatusPatches.cs
@@ -17,6 +17,9 @@ public static class ShipStatus_FixedUpdate
         MalumCheats.KickVentsCheat();
 
         MalumPPMCheats.ReportBodyPPM();
+
+        MalumNewCheats.SetAllSameColorPPM();
+        MalumNewCheats.SendPrivateMessagePPM();
     }
 }
 

--- a/src/UI/Elements/CheatToggles.cs
+++ b/src/UI/Elements/CheatToggles.cs
@@ -74,6 +74,7 @@ public struct CheatToggles
     public static bool longerMessages;
     public static bool unlockClipboard;
     public static bool lowerRateLimits;
+    public static bool sendPrivateMessage;
 
     // Ship
     public static bool closeMeeting;
@@ -155,6 +156,7 @@ public struct CheatToggles
     public static bool killAll;
     public static bool killAllCrew;
     public static bool killAllImps;
+    public static bool setAllSameColor;
 
     // Passive
     public static bool unlockFeatures;
@@ -207,11 +209,13 @@ public struct CheatToggles
         setFakeAlive = variableToKeep == "setFakeAlive" && setFakeAlive;
         forceRole = variableToKeep == "forceRole" && forceRole;
         teleportPlayer = variableToKeep == "teleportPlayer" && teleportPlayer;
+        setAllSameColor = variableToKeep == "setAllSameColor" && setAllSameColor;
+        sendPrivateMessage = variableToKeep == "sendPrivateMessage" && sendPrivateMessage;
     }
 
     public static bool ShouldPPMClose()
     {
-        return !setFakeRole && !setFakeAlive && !forceRole && !ejectPlayer && !reportBody && !telekillPlayer && !killPlayer && !spectate && !teleportPlayer;
+        return !setFakeRole && !setFakeAlive && !forceRole && !ejectPlayer && !reportBody && !telekillPlayer && !killPlayer && !spectate && !teleportPlayer && !setAllSameColor && !sendPrivateMessage;
     }
 
     // Disables all cheat toggles by setting all to false using the cached ToggleFields

--- a/src/UI/Windows/MenuUI.cs
+++ b/src/UI/Windows/MenuUI.cs
@@ -171,6 +171,7 @@ public class MenuUI : MonoBehaviour
             CheatToggles.showProtectMenu = false;
             CheatToggles.showRolesMenu = false;
             CheatToggles.noOptionsLimits = false;
+            CheatToggles.setAllSameColor = false;
         }
 
         // Some cheats only work if in a meeting, so they are turned off if it does not
@@ -183,6 +184,9 @@ public class MenuUI : MonoBehaviour
 
     public void OnGUI()
     {
+        // Always draw PM notification banner (even when menu is closed, since user types in game chat)
+        PrivateMessageState.DrawNotification();
+
         if (!isGUIActive || MalumMenu.isPanicked) return;
 
         InitStyles();

--- a/src/UI/Windows/PrivateMessageUI.cs
+++ b/src/UI/Windows/PrivateMessageUI.cs
@@ -1,0 +1,91 @@
+using UnityEngine;
+
+namespace MalumMenu;
+
+/// <summary>
+/// Lightweight private message state manager.
+/// Does NOT hold any IL2CPP object references to avoid dangling pointer crashes.
+/// Only stores the target player's ID (a byte) and name (a managed string).
+/// The notification banner is drawn inside MenuUI.OnGUI to avoid a separate MonoBehaviour.
+/// </summary>
+public static class PrivateMessageState
+{
+    public static bool isPrivateMode;
+    public static byte targetPlayerId;
+    public static string targetName = "";
+
+    /// <summary>
+    /// Activates private message mode for the specified target.
+    /// Only stores safe primitive values, never IL2CPP object references.
+    /// </summary>
+    public static void Activate(byte playerId, string playerName)
+    {
+        targetPlayerId = playerId;
+        targetName = playerName;
+        isPrivateMode = true;
+
+        // Open the in-game chat so the user can type their message there
+        Utils.OpenChat();
+    }
+
+    /// <summary>
+    /// Deactivates private message mode.
+    /// </summary>
+    public static void Cancel()
+    {
+        isPrivateMode = false;
+        targetPlayerId = 0;
+        targetName = "";
+    }
+
+    /// <summary>
+    /// Gets the target PlayerControl by looking up the stored player ID at call time.
+    /// This avoids holding stale IL2CPP references.
+    /// Returns null if the player is no longer valid.
+    /// </summary>
+    public static PlayerControl GetTargetPlayer()
+    {
+        if (!isPrivateMode) return null;
+
+        try
+        {
+            foreach (var player in PlayerControl.AllPlayerControls)
+            {
+                if (player != null && player.Data != null && player.PlayerId == targetPlayerId)
+                {
+                    return player;
+                }
+            }
+        }
+        catch { }
+
+        return null;
+    }
+
+    /// <summary>
+    /// Draws the notification banner. Called from MenuUI.OnGUI() to avoid
+    /// needing a separate MonoBehaviour.
+    /// </summary>
+    public static void DrawNotification()
+    {
+        if (!isPrivateMode) return;
+
+        float bannerWidth = 400f;
+        float bannerHeight = 30f;
+        Rect bannerRect = new Rect(
+            Screen.width / 2f - bannerWidth / 2f,
+            8f,
+            bannerWidth,
+            bannerHeight
+        );
+
+        GUI.Box(bannerRect, $"  PM MODE -> {targetName}  |  Type in chat & send  |  ESC = cancel");
+
+        // Allow cancelling with Escape key
+        if (Event.current.type == EventType.KeyDown && Event.current.keyCode == KeyCode.Escape)
+        {
+            Cancel();
+            Event.current.Use();
+        }
+    }
+}

--- a/src/UI/Windows/Tabs/ChatTab.cs
+++ b/src/UI/Windows/Tabs/ChatTab.cs
@@ -16,6 +16,10 @@ public class ChatTab : ITab
 
         DrawTextbox();
 
+        GUILayout.Space(15);
+
+        DrawPrivate();
+
         GUILayout.EndVertical();
     }
 
@@ -37,5 +41,12 @@ public class ChatTab : ITab
         CheatToggles.longerMessages = GUILayout.Toggle(CheatToggles.longerMessages, " Allow Longer Messages");
 
         CheatToggles.unlockClipboard = GUILayout.Toggle(CheatToggles.unlockClipboard, " Unlock Clipboard");
+    }
+
+    private void DrawPrivate()
+    {
+        GUILayout.Label("Private", GUIStylePreset.TabSubtitle);
+
+        CheatToggles.sendPrivateMessage = GUILayout.Toggle(CheatToggles.sendPrivateMessage, " Send Private Message");
     }
 }

--- a/src/UI/Windows/Tabs/HostOnlyTab.cs
+++ b/src/UI/Windows/Tabs/HostOnlyTab.cs
@@ -22,6 +22,10 @@ public class HostOnlyTab : ITab
 
         DrawGameState();
 
+        GUILayout.Space(15);
+
+        DrawCosmetics();
+
         GUILayout.EndVertical();
 
         GUILayout.BeginVertical();
@@ -81,5 +85,12 @@ public class HostOnlyTab : ITab
         CheatToggles.voteImmune = GUILayout.Toggle(CheatToggles.voteImmune, " Vote Immune");
 
         CheatToggles.ejectPlayer = GUILayout.Toggle(CheatToggles.ejectPlayer, " Eject Player");
+    }
+
+    private void DrawCosmetics()
+    {
+        GUILayout.Label("Cosmetics", GUIStylePreset.TabSubtitle);
+
+        CheatToggles.setAllSameColor = GUILayout.Toggle(CheatToggles.setAllSameColor, " Set All Same Color");
     }
 }

--- a/src/Utilities/Utils.cs
+++ b/src/Utilities/Utils.cs
@@ -714,6 +714,8 @@ public static class Utils
         UnityEngine.Object.Destroy(MalumMenu.protectUI);
         // UnityEngine.Object.Destroy(MalumMenu.rolesUI);
 
+        PrivateMessageState.Cancel();
+
         UnityEngine.Object.Destroy(MalumMenu.keybindListener);
 
         PanicCleaner.Create();


### PR DESCRIPTION
## Description
This PR introduces two new features using the existing Player Pick Menu (PPM) system, keeping the existing GUI fully intact and crash-safe:

- **Host-Only: Set All Same Color:** Allows the host to open a PPM, select a color, and force all players in the lobby to that color.
- **Any-One: Send Private Message:** Allows any player to select a target from the PPM. The next message typed in the regular game chat will be intercepted and sent only to the target player using targeted RPC.

Both features are safely implemented without holding onto native IL2CPP object references to prevent memory access violations.