### PR TITLE
Make noKillCd more effective

### DIFF
--- a/src/Cheats/MalumCheats.cs
+++ b/src/Cheats/MalumCheats.cs
@@ -83,14 +83,6 @@ public static class MalumCheats
         CheatToggles.forceStartGame = false;
     }
 
-    public static void NoKillCdCheat(PlayerControl playerControl)
-    {
-        if (CheatToggles.noKillCd && playerControl.killTimer > 0f)
-        {
-            playerControl.SetKillTimer(0f);
-        }
-    }
-
     public static void CompleteMyTasksCheat()
     {
         if (CheatToggles.completeMyTasks)

--- a/src/Patches/PlayerControlPatches.cs
+++ b/src/Patches/PlayerControlPatches.cs
@@ -3,17 +3,15 @@ using UnityEngine;
 
 namespace MalumMenu;
 
-[HarmonyPatch(typeof(PlayerControl), nameof(PlayerControl.FixedUpdate))]
-public static class PlayerControl_FixedUpdate
+[HarmonyPatch(typeof(PlayerControl), nameof(PlayerControl.SetKillTimer))]
+public static class PlayerControl_SetKillTimer
 {
-    public static void Postfix(PlayerControl __instance)
+    // Prefix patch of PlayerControl.SetKillTimer to remove kill cooldown
+    public static void Prefix(PlayerControl __instance, ref float time)
     {
+        if (!__instance.AmOwner || !Utils.isHost || !CheatToggles.noKillCd) return;
 
-        if (__instance.AmOwner)
-        {
-            MalumCheats.NoKillCdCheat(__instance);
-        }
-
+        time = 0f;
     }
 }
 


### PR DESCRIPTION
- **Refactor**: Patch `PlayerControl.SetKillTimer` directly for the noKillCd feature as doing so ensures the cooldown is never set above 0 (not even for a split second).