### PR TITLE
fixed sabotage map not showing the ESP minimap players

### DIFF
--- a/src/Patches/MapBehaviourPatches.cs
+++ b/src/Patches/MapBehaviourPatches.cs
@@ -44,32 +44,56 @@ public static class MapBehaviour_ShowNormalMap
     }
 }
 
+
 [HarmonyPatch(typeof(MapBehaviour), nameof(MapBehaviour.FixedUpdate))]
 public static class MapBehaviour_FixedUpdate
 {
     // Postfix patch of MapBehaviour.FixedUpdate to update each herePoint icon's color and position on the map based on their respective player
     public static void Postfix(MapBehaviour __instance)
     {
-        // Reset map if miniMap cheat is disabled
-        if (MinimapHandler.IsCheatEnabled() != MinimapHandler.minimapActive)
+        bool cheatEnabled = MinimapHandler.IsCheatEnabled();
+
+        // Spawn herePoints if they don't exist and the cheat is enabled (handles both normal and sabotage maps)
+        if (cheatEnabled && MinimapHandler.herePoints.Count == 0)
         {
-            if (!__instance.infectedOverlay.gameObject.active) // Do not affect sabotage map
+            var temp = new List<HerePoint>();
+            foreach (var player in PlayerControl.AllPlayerControls)
             {
-                __instance.Close();
-                __instance.ShowNormalMap();
+                if (!player.AmOwner)
+                {
+                    var herePoint = UnityEngine.Object.Instantiate(__instance.HerePoint, __instance.HerePoint.transform.parent);
+                    temp.Add(new HerePoint(player, herePoint));
+                }
             }
+            MinimapHandler.herePoints = temp;
         }
+
+        // Clean up herePoints if cheat got disabled
+        if (!cheatEnabled && MinimapHandler.herePoints.Count > 0)
+        {
+            try
+            {
+                MinimapHandler.herePoints.ForEach(x => UnityEngine.Object.Destroy(x.sprite.gameObject));
+                MinimapHandler.herePoints.Clear();
+            }
+            catch { }
+        }
+
+        MinimapHandler.minimapActive = cheatEnabled;
 
         // Properly handles each herePoint icon on the map
-        var temp = MinimapHandler.herePoints;
-        foreach (var herePoint in temp)
+        if (cheatEnabled)
         {
-            MinimapHandler.HandleHerePoint(herePoint);
-        }
+            var herePoints = MinimapHandler.herePoints;
+            foreach (var herePoint in herePoints)
+            {
+                MinimapHandler.HandleHerePoint(herePoint);
+            }
 
-        foreach (var herePoint in MinimapHandler.herePointsToRemove)
-        {
-            MinimapHandler.herePoints.Remove(herePoint);
+            foreach (var herePoint in MinimapHandler.herePointsToRemove)
+            {
+                MinimapHandler.herePoints.Remove(herePoint);
+            }
         }
 
     }


### PR DESCRIPTION
Now all the ESP modules work with the sabotage imposter map so you don't need to manually open the normal map to see other players
fixes sameer0199's comment in #590
<img width="1733" height="953" alt="ScreenShot2026-05-10 130851" src="https://github.com/user-attachments/assets/f7c594a4-4e8d-4750-9803-087ca9c04714" />
