### PR TITLE
Automatically create profile file if it is missing

### DIFF
--- a/src/MalumMenu.cs
+++ b/src/MalumMenu.cs
@@ -1,4 +1,5 @@
-﻿using BepInEx;
+﻿using System.IO;
+using BepInEx;
 using BepInEx.Unity.IL2CPP;
 using UnityEngine.SceneManagement;
 using System;
@@ -18,6 +19,7 @@ public partial class MalumMenu : BasePlugin
     public Harmony Harmony { get; } = new(Id);
     public static MalumMenu Plugin;
     public new static ManualLogSource Log;
+    public static readonly string ProfilePath = Path.Combine(Paths.ConfigPath, "MalumProfile.txt");
 
     public static MenuUI menuUI;
     public static ConsoleUI consoleUI;
@@ -202,7 +204,13 @@ public partial class MalumMenu : BasePlugin
             PerformanceReporting.enabled = false;
         }
 
-        // Load profile on start
+        // Create profile file if it is missing
+        if (!File.Exists(ProfilePath))
+        {
+            CheatToggles.SaveTogglesToProfile();
+        }
+
+        // Auto load profile on start if needed
         if (autoLoadProfile.Value)
         {
             CheatToggles.LoadTogglesFromProfile();

--- a/src/UI/Elements/CheatToggles.cs
+++ b/src/UI/Elements/CheatToggles.cs
@@ -180,8 +180,6 @@ public struct CheatToggles
     // Map for Reflection Access: Toggle Name -> FieldInfo
     public static readonly Dictionary<string, FieldInfo> ToggleFields = new();
 
-    public static readonly string ProfilePath = Path.Combine(BepInEx.Paths.ConfigPath, "MalumProfile.txt");
-
     // Populate reflection map once at startup and initialize Keybinds with KeyCode.None
     static CheatToggles()
     {
@@ -227,7 +225,7 @@ public struct CheatToggles
     // Format per line: ToggleName = True/False = KeyCode.KEY
     public static void SaveTogglesToProfile()
     {
-        using var writer = new StreamWriter(ProfilePath);
+        using var writer = new StreamWriter(MalumMenu.ProfilePath);
 
         writer.WriteLine("# MalumProfile");
         writer.WriteLine("# Format: ToggleName = True/False = KeyCode.KEY");
@@ -248,9 +246,9 @@ public struct CheatToggles
     // Format per line: ToggleName = True/False = KeyCode.KEY
     public static void LoadTogglesFromProfile()
     {
-        if (!File.Exists(ProfilePath)) return;
+        if (!File.Exists(MalumMenu.ProfilePath)) return;
 
-        using var reader = new StreamReader(ProfilePath);
+        using var reader = new StreamReader(MalumMenu.ProfilePath);
 
         while (reader.ReadLine() is { } line)
         {


### PR DESCRIPTION
- **Feat**: Automatically create a blank profile file when it is missing
  - Before this change, the file was created only after the user manually saved a profile through the UI.
  - This change lets people edit their profile file at any time without first having to save it in-game.