### PR TITLE
added a way to open the meeting after closing it

### DIFF
--- a/src/Cheats/MalumCheats.cs
+++ b/src/Cheats/MalumCheats.cs
@@ -10,16 +10,36 @@ public static class MalumCheats
     private static bool _isScanAnimActive;
     private static bool _isCamsAnimActive;
 
+    public static bool isServerInMeeting = false;
+
+    public static void OpenMeetingCheat()
+    {
+        if (!CheatToggles.openMeeting) return;
+
+        if (!Utils.isMeeting && isServerInMeeting && _meetingHudInstance != null)
+        {
+            MeetingHud.Instance = _meetingHudInstance;
+            _meetingHudInstance.gameObject.SetActive(true);
+
+            Camera.main.GetComponent<FollowerCamera>().Locked = true;
+            DestroyableSingleton<HudManager>.Instance.SetMapButtonEnabled(false);
+            DestroyableSingleton<HudManager>.Instance.SetHudActive(false);
+        }
+
+        CheatToggles.openMeeting = false;
+    }
+
+    private static MeetingHud _meetingHudInstance;
+
     public static void CloseMeetingCheat()
     {
         if (!CheatToggles.closeMeeting) return;
 
         if (Utils.isMeeting) // Closes MeetingHud window if it's open
         {
-
-            // Destroy MeetingHud window gameobject
-            MeetingHud.Instance.DespawnOnDestroy = false;
-            Object.Destroy(MeetingHud.Instance.gameObject);
+            _meetingHudInstance = MeetingHud.Instance;
+            _meetingHudInstance.gameObject.SetActive(false);
+            MeetingHud.Instance = null;
 
             // Gameplay must be reenabled
             DestroyableSingleton<HudManager>.Instance.StartCoroutine(DestroyableSingleton<HudManager>.Instance.CoFadeFullScreen(Color.black, Color.clear, 0.2f, false));

--- a/src/Patches/MeetingHudPatches.cs
+++ b/src/Patches/MeetingHudPatches.cs
@@ -5,6 +5,24 @@ using Object = UnityEngine.Object;
 
 namespace MalumMenu;
 
+[HarmonyPatch(typeof(MeetingHud), nameof(MeetingHud.Start))]
+public static class MeetingHud_Start
+{
+    public static void Postfix(MeetingHud __instance)
+    {
+        MalumCheats.isServerInMeeting = true;
+    }
+}
+
+[HarmonyPatch(typeof(ExileController), nameof(ExileController.WrapUp))]
+public static class ExileController_WrapUp
+{
+    public static void Postfix()
+    {
+        MalumCheats.isServerInMeeting = false;
+    }
+}
+
 [HarmonyPatch(typeof(MeetingHud), nameof(MeetingHud.Update))]
 public static class MeetingHud_Update
 {

--- a/src/Patches/ShipStatusPatches.cs
+++ b/src/Patches/ShipStatusPatches.cs
@@ -11,6 +11,7 @@ public static class ShipStatus_FixedUpdate
         MalumCheats.OpenSabotageMapCheat();
 
         MalumCheats.CloseMeetingCheat();
+        MalumCheats.OpenMeetingCheat();
         MalumCheats.SkipMeetingCheat();
         MalumCheats.CallMeetingCheat();
         MalumCheats.WalkInVentCheat();

--- a/src/UI/Elements/CheatToggles.cs
+++ b/src/UI/Elements/CheatToggles.cs
@@ -77,6 +77,7 @@ public struct CheatToggles
 
     // Ship
     public static bool closeMeeting;
+    public static bool openMeeting;
     public static bool autoOpenDoorsOnUse;
     public static bool unfixableLights;
     public static bool callMeeting;

--- a/src/UI/Windows/Tabs/ShipTab.cs
+++ b/src/UI/Windows/Tabs/ShipTab.cs
@@ -39,6 +39,8 @@ public class ShipTab : ITab
 
         CheatToggles.closeMeeting = GUILayout.Toggle(CheatToggles.closeMeeting, " Close Meeting");
 
+        CheatToggles.openMeeting = GUILayout.Toggle(CheatToggles.openMeeting, " Open Meeting");
+
         CheatToggles.autoOpenDoorsOnUse = GUILayout.Toggle(CheatToggles.autoOpenDoorsOnUse, " Auto-Open Doors On Use");
     }
 


### PR DESCRIPTION
Adds an open meeting button. Checks if a meeting is in progress and not already open before opening it. If no meeting is in progress, nothing happens.
Addition for #218