### PR TITLE
Add close button to UI windows

### DIFF
--- a/src/UI/Utilities/GUIStylePreset.cs
+++ b/src/UI/Utilities/GUIStylePreset.cs
@@ -8,9 +8,12 @@ public static class GUIStylePreset
     private static GUIStyle _darkSeparator;
     private static GUIStyle _normalButton;
     private static GUIStyle _normalToggle;
+    private static GUIStyle _flatButton;
     private static GUIStyle _tabButton;
     private static GUIStyle _tabTitle;
     private static GUIStyle _tabSubtitle;
+
+    private static Texture2D _flatButtonTex;
 
     public static GUIStyle Separator
     {
@@ -79,6 +82,38 @@ public static class GUIStylePreset
             }
 
             return _normalToggle;
+        }
+    }
+
+    public static GUIStyle FlatButton
+    {
+        get
+        {
+            if (_flatButton == null)
+            {
+                var style = new GUIStyle(GUI.skin.label)
+                {
+                    wordWrap = false,
+                    alignment = TextAnchor.MiddleCenter
+                };
+
+                var toggle = GUI.skin.toggle;
+                style.normal.textColor = toggle.normal.textColor;
+                style.hover.textColor = toggle.hover.textColor;
+
+                _flatButtonTex = new Texture2D(1, 1)
+                {
+                    hideFlags = HideFlags.HideAndDontSave
+                };
+                _flatButtonTex.SetPixels(new[] { new Color(0.5f, 0.5f, 0.5f, 0.5f) });
+                _flatButtonTex.Apply();
+                style.hover.background = _flatButtonTex;
+
+                style.name = nameof(_flatButton);
+                _flatButton = style;
+            }
+
+            return _flatButton;
         }
     }
 

--- a/src/UI/Windows/ConsoleUI.cs
+++ b/src/UI/Windows/ConsoleUI.cs
@@ -42,6 +42,14 @@ public class ConsoleUI : MonoBehaviour
 
     private void ConsoleWindow(int windowID)
     {
+        var buttonSize = new Vector2(40f, 15f);
+        var buttonPos = new Vector2(windowWidth - buttonSize.x, 2f);
+        var buttonRect = new Rect(buttonPos, buttonSize);
+        if (GUI.Button(buttonRect, "✕", GUIStylePreset.FlatButton))
+        {
+            CheatToggles.showConsole = false;
+        }
+
         GUILayout.BeginVertical(GUI.skin.box);
 
         _scrollPosition = GUILayout.BeginScrollView(_scrollPosition, false, false);

--- a/src/UI/Windows/DoorsUI.cs
+++ b/src/UI/Windows/DoorsUI.cs
@@ -34,6 +34,15 @@ public class DoorsUI : MonoBehaviour
 
     private void DoorsWindow(int windowID)
     {
+        var buttonSize = new Vector2(40f, 15f);
+        var buttonPos = new Vector2(windowWidth - buttonSize.x, 2f);
+        var buttonRect = new Rect(buttonPos, buttonSize);
+        if (GUI.Button(buttonRect, "✕", GUIStylePreset.FlatButton))
+        {
+            CheatToggles.showDoorsMenu = false;
+        }
+
+
         if (!Utils.isShip)
         {
             GUI.DragWindow();

--- a/src/UI/Windows/OverloadUI.cs
+++ b/src/UI/Windows/OverloadUI.cs
@@ -147,6 +147,14 @@ public class OverloadUI : MonoBehaviour
 
     private void OverloadWindow(int windowID)
     {
+        var buttonSize = new Vector2(40f, 15f);
+        var buttonPos = new Vector2(_windowRect.size.x - buttonSize.x, 2f);
+        var buttonRect = new Rect(buttonPos, buttonSize);
+        if (GUI.Button(buttonRect, "✕", GUIStylePreset.FlatButton))
+        {
+            CheatToggles.showOverload = false;
+        }
+
         GUILayout.BeginHorizontal();
 
         GUILayout.Space(15f);

--- a/src/UI/Windows/ProtectUI.cs
+++ b/src/UI/Windows/ProtectUI.cs
@@ -35,6 +35,14 @@ public class ProtectUI : MonoBehaviour
 
     private void ProtectWindow(int windowID)
     {
+        var buttonSize = new Vector2(40f, 15f);
+        var buttonPos = new Vector2(windowWidth - buttonSize.x, 2f);
+        var buttonRect = new Rect(buttonPos, buttonSize);
+        if (GUI.Button(buttonRect, "✕", GUIStylePreset.FlatButton))
+        {
+            CheatToggles.showProtectMenu = false;
+        }
+
         GUILayout.BeginVertical();
 
         _scrollPosition = GUILayout.BeginScrollView(_scrollPosition, false, true);

--- a/src/UI/Windows/RolesUI.cs
+++ b/src/UI/Windows/RolesUI.cs
@@ -32,6 +32,14 @@ public class RolesUI : MonoBehaviour
 
     private void RolesWindow(int windowID)
     {
+        var buttonSize = new Vector2(40f, 15f);
+        var buttonPos = new Vector2(windowWidth - buttonSize.x, 2f);
+        var buttonRect = new Rect(buttonPos, buttonSize);
+        if (GUI.Button(buttonRect, "✕", GUIStylePreset.FlatButton))
+        {
+            CheatToggles.showRolesMenu = false;
+        }
+
         GUILayout.BeginVertical();
 
         _scrollPosition = GUILayout.BeginScrollView(_scrollPosition, false, true);

--- a/src/UI/Windows/TasksUI.cs
+++ b/src/UI/Windows/TasksUI.cs
@@ -42,6 +42,14 @@ public class TasksUI : MonoBehaviour
 
     private void TasksWindow(int windowID)
     {
+        var buttonSize = new Vector2(40f, 15f);
+        var buttonPos = new Vector2(windowWidth - buttonSize.x, 2f);
+        var buttonRect = new Rect(buttonPos, buttonSize);
+        if (GUI.Button(buttonRect, "✕", GUIStylePreset.FlatButton))
+        {
+            CheatToggles.showTasksMenu = false;
+        }
+
         GUILayout.BeginVertical();
 
         _scrollPosition = GUILayout.BeginScrollView(_scrollPosition, false, true);


### PR DESCRIPTION
Very simple, just adds a `x` button in the top right corner of every window to easily close them instead of having to search for their toggle in the UI.

### Additional notes

I didn't add a close button to the main window for now, please test and give feedback.

If we decide on adding it to the main window too, behavior regarding `KeepSubwindowsOpen` has to be tested and potentially adjusted.

I decided not to create a helper function to draw the buttons, as we would have to access the window rect and related CheatToggle in it somehow, and passing them as parameters felt a little unclean.