### PR TITLE
fixed sabotage map not showing the ESP minimap players

### DIFF
--- a/src/Patches/MapBehaviourPatches.cs
+++ b/src/Patches/MapBehaviourPatches.cs
@@ -1,8 +1,6 @@
 using HarmonyLib;
 using System.Collections.Generic;
-
 namespace MalumMenu;
-
 [HarmonyPatch(typeof(MapBehaviour), nameof(MapBehaviour.ShowNormalMap))]
 public static class MapBehaviour_ShowNormalMap
 {
@@ -10,16 +8,12 @@ public static class MapBehaviour_ShowNormalMap
     public static void Postfix(MapBehaviour __instance)
     {
         MinimapHandler.minimapActive = MinimapHandler.IsCheatEnabled();
-
         if (!MinimapHandler.minimapActive)
         {
             return; // Only runs if miniMap Cheat is enabled
         }
-
         __instance.ColorControl.SetColor(Palette.Purple); // Custom map color
-
         __instance.DisableTrackerOverlays();
-
         // Destroy old player icons (herePoints)
         try
         {
@@ -27,7 +21,6 @@ public static class MapBehaviour_ShowNormalMap
             MinimapHandler.herePoints.Clear();
         }
         catch { }
-
         // & create new ones for each player
         var temp = new List<HerePoint>();
         foreach (var player in PlayerControl.AllPlayerControls)
@@ -35,46 +28,64 @@ public static class MapBehaviour_ShowNormalMap
             if (!player.AmOwner) // LocalPlayer is always treated normally
             {
                 var herePoint = UnityEngine.Object.Instantiate(__instance.HerePoint, __instance.HerePoint.transform.parent);
-
                 temp.Add(new HerePoint(player, herePoint));
             }
         }
         MinimapHandler.herePoints = temp;
-
     }
 }
-
 [HarmonyPatch(typeof(MapBehaviour), nameof(MapBehaviour.FixedUpdate))]
 public static class MapBehaviour_FixedUpdate
 {
     // Postfix patch of MapBehaviour.FixedUpdate to update each herePoint icon's color and position on the map based on their respective player
     public static void Postfix(MapBehaviour __instance)
     {
-        // Reset map if miniMap cheat is disabled
-        if (MinimapHandler.IsCheatEnabled() != MinimapHandler.minimapActive)
+        bool cheatEnabled = MinimapHandler.IsCheatEnabled();
+
+        // Spawn herePoints if they don't exist and the cheat is enabled (handles both normal and sabotage maps)
+        if (cheatEnabled && MinimapHandler.herePoints.Count == 0)
         {
-            if (!__instance.infectedOverlay.gameObject.active) // Do not affect sabotage map
+            var temp = new List<HerePoint>();
+            foreach (var player in PlayerControl.AllPlayerControls)
             {
-                __instance.Close();
-                __instance.ShowNormalMap();
+                if (!player.AmOwner)
+                {
+                    var herePoint = UnityEngine.Object.Instantiate(__instance.HerePoint, __instance.HerePoint.transform.parent);
+                    temp.Add(new HerePoint(player, herePoint));
+                }
             }
+            MinimapHandler.herePoints = temp;
         }
+
+        // Clean up herePoints if cheat got disabled
+        if (!cheatEnabled && MinimapHandler.herePoints.Count > 0)
+        {
+            try
+            {
+                MinimapHandler.herePoints.ForEach(x => UnityEngine.Object.Destroy(x.sprite.gameObject));
+                MinimapHandler.herePoints.Clear();
+            }
+            catch { }
+        }
+
+        MinimapHandler.minimapActive = cheatEnabled;
 
         // Properly handles each herePoint icon on the map
-        var temp = MinimapHandler.herePoints;
-        foreach (var herePoint in temp)
+        if (cheatEnabled)
         {
-            MinimapHandler.HandleHerePoint(herePoint);
-        }
+            var herePoints = MinimapHandler.herePoints;
+            foreach (var herePoint in herePoints)
+            {
+                MinimapHandler.HandleHerePoint(herePoint);
+            }
 
-        foreach (var herePoint in MinimapHandler.herePointsToRemove)
-        {
-            MinimapHandler.herePoints.Remove(herePoint);
+            foreach (var herePoint in MinimapHandler.herePointsToRemove)
+            {
+                MinimapHandler.herePoints.Remove(herePoint);
+            }
         }
-
     }
 }
-
 [HarmonyPatch(typeof(MapBehaviour), nameof(MapBehaviour.Close))]
 public static class MapBehaviour_Close
 {


### PR DESCRIPTION
Now all the ESP modules work with the sabotage imposter map so you don't need to manually open the normal map to see other players

this is a duplication of https://github.com/scp222thj/MalumMenu/pull/612 because it couldn't be reopened

<img width="1733" height="953" alt="image" src="https://github.com/user-attachments/assets/136bc4d5-b5df-4082-b179-b10d83ceebc9" />
