### PR TITLE
feat: re-enable "Allow Tasks" for impostors

### DIFF
--- a/src/Patches/OtherPatches.cs
+++ b/src/Patches/OtherPatches.cs
@@ -321,18 +321,24 @@ public static class MushroomDoorSabotageMinigame_Begin
     }
 }
 
-// NEEDS FIX : Blocks usage of consoles to which impostor
-// has access to (like those to fix sabotages) when cheat is disabled
+[HarmonyPatch(typeof(Console), nameof(Console.CanUse))]
+public static class Console_CanUse
+{
+    public static void Prefix(Console __instance, ref bool __state)
+    {
+        if (!CheatToggles.impostorTasks) return;
+        __state = __instance.AllowImpostor;
+        __instance.AllowImpostor = true;
+    }
 
-// [HarmonyPatch(typeof(Console), nameof(Console.CanUse))]
-// public static class Console_CanUse
-// {
-//     // Prefix patch of Console.CanUse to allow impostors to do tasks
-//     public static void Prefix(Console __instance)
-//     {
-//         __instance.AllowImpostor = CheatToggles.impostorTasks;
-//     }
-// }
+    public static void Postfix(Console __instance, ref bool __state)
+    {
+        if (CheatToggles.impostorTasks)
+        {
+            __instance.AllowImpostor = __state;
+        }
+    }
+}
 
 [HarmonyPatch(typeof(IntroCutscene), "CoBegin")]
 public static class IntroCutscene_CoBegin

--- a/src/Patches/PlayerPhysicsPatches.cs
+++ b/src/Patches/PlayerPhysicsPatches.cs
@@ -48,6 +48,12 @@ public static class PlayerPhysics_LateUpdate
 
             if (!deadBody || deadBody.Reported) continue;  // Only draw tracers for unreported dead bodies
             TracersHandler.DrawBodyTracer(deadBody);
+
+            if (CheatToggles.autoReportBodies)
+            {
+                PlayerControl.LocalPlayer.CmdReportDeadBody(GameData.Instance.GetPlayerById(deadBody.ParentId));
+                break;
+            }
         }
 
         try

--- a/src/Patches/PlayerPhysicsPatches.cs
+++ b/src/Patches/PlayerPhysicsPatches.cs
@@ -45,14 +45,17 @@ public static class PlayerPhysics_LateUpdate
         foreach(GameObject bodyObject in bodyObjects) // Finds and loops through all dead bodies
         {
             DeadBody deadBody = bodyObject.GetComponent<DeadBody>();
+            if (!deadBody) continue;
 
-            if (!deadBody || deadBody.Reported) continue;  // Only draw tracers for unreported dead bodies
             TracersHandler.DrawBodyTracer(deadBody);
 
             if (CheatToggles.autoReportBodies)
             {
+                if (deadBody.Reported) continue;
+
+                deadBody.Reported = true;
+
                 PlayerControl.LocalPlayer.CmdReportDeadBody(GameData.Instance.GetPlayerById(deadBody.ParentId));
-                break;
             }
         }
 

--- a/src/UI/Elements/CheatToggles.cs
+++ b/src/UI/Elements/CheatToggles.cs
@@ -81,6 +81,7 @@ public struct CheatToggles
     public static bool unfixableLights;
     public static bool callMeeting;
     public static bool reportBody;
+    public static bool autoReportBodies;
 
     // Sabotage
     public static bool commsSab;

--- a/src/UI/Windows/Tabs/RolesTab.cs
+++ b/src/UI/Windows/Tabs/RolesTab.cs
@@ -62,7 +62,7 @@ public class RolesTab : ITab
 
         CheatToggles.killReach = GUILayout.Toggle(CheatToggles.killReach, " Kill Reach");
 
-        // CheatToggles.impostorTasks = GUILayout.Toggle(CheatToggles.impostorTasks, " Allow Tasks");
+        CheatToggles.impostorTasks = GUILayout.Toggle(CheatToggles.impostorTasks, " Allow Tasks");
     }
 
     private void DrawShapeshifter()

--- a/src/UI/Windows/Tabs/ShipTab.cs
+++ b/src/UI/Windows/Tabs/ShipTab.cs
@@ -39,6 +39,8 @@ public class ShipTab : ITab
 
         CheatToggles.closeMeeting = GUILayout.Toggle(CheatToggles.closeMeeting, " Close Meeting");
 
+        CheatToggles.autoReportBodies = GUILayout.Toggle(CheatToggles.autoReportBodies, " Auto-Report Dead Bodies");
+
         CheatToggles.autoOpenDoorsOnUse = GUILayout.Toggle(CheatToggles.autoOpenDoorsOnUse, " Auto-Open Doors On Use");
     }
 


### PR DESCRIPTION
Re-enables the impostor tasks toggle in the Roles tab.

Uses prefix/postfix with `__state` to temporarily set `AllowImpostor = true` only when the toggle is active, then restores the original value — so sabotage consoles are unaffected.