### PR TITLE
feat: 33 new features — ESP, tracers, console, host tools, mod chat, troll, and more

### DIFF
--- a/FEATURES.md
+++ b/FEATURES.md
@@ -22,6 +22,7 @@
 |------------|-------------|------|--------|
 | to Cursor | Teleport by right-clicking with your cursor. Works best with the ZoomOut cheat | Toggle | Off |
 | to Player | Teleport to a player's position by selecting them | Menu |
+| Blink to Cursor | Snap-teleport to your cursor position using middle mouse button | Toggle | Off |
 
 ## 👁️ ESP
 
@@ -34,6 +35,8 @@ MalumMenu's ESP cheats are completely client-side, and thus undetectable by anti
 | No Shadows | Removes all shadows, allowing you to see during blackouts and even through walls<br>Also, lets you see through spore clouds in the Fungle Jungle | Toggle | Off |
 | Reveal Votes | Reveals votes as they are being cast rather than at the end of the meeting<br>Also, lets you see colored votes even if votes are set to anonymous | Toggle | Off |
 | Always Chat | Keeps the chat icon always enabled, allowing you to chat at any time (even while not in a meeting or the lobby) | Toggle | Off |
+| Vision Boost | Massively increases your vision range, ignoring light modifiers | Toggle | Off |
+| Player Notes | Attach private notes to any player, visible only to you on their nametag | Toggle | Off |
 
 #### Camera
     
@@ -52,6 +55,10 @@ MalumMenu's ESP cheats are completely client-side, and thus undetectable by anti
 | Ghosts | Shows tracer lines for ghosts (color: white) | Toggle | Off |
 | Dead Bodies | Shows tracer lines for dead bodies on the ground (color: yellow) | Toggle | Off |
 | Color-based | Changes the color of tracer lines to the color of their players| Toggle | Off |
+| Vent Paths | Shows lines connecting all vents on the current map | Toggle | Off |
+| Footprints | Leaves fading colored footprints showing where each player has walked | Toggle | Off |
+| Player Trail | Draws a fading trail behind your own movement | Toggle | Off |
+| Kill Range Indicator | Draws a circle around you showing your current kill range | Toggle | Off |
 
 #### Minimap
 
@@ -67,6 +74,8 @@ MalumMenu's ESP cheats are completely client-side, and thus undetectable by anti
 | Cheat | Description | Type | Default |
 |------------|-------------|------|----|
 | Set Fake Role | Change your current role to any role you want<br>(Shapeshifter & Phantom are disabled by default to prevent getting detected by the anticheat) | Menu |
+| Fake Shapeshift | Shapeshift into any player visually without being Shapeshifter — works for any role including crewmates, non-hosts | Menu |
+| Force Role | (Host only) Assign any role to any player | Menu |
 
 #### Impostor
 
@@ -75,6 +84,7 @@ MalumMenu's ESP cheats are completely client-side, and thus undetectable by anti
 | Kill Anyone | Allows you to kill anyone, regardless if they are protected, impostors, crawling in a vent, or a ghost | Toggle | Off |
 | No Kill Cooldown | Removes the cooldown period after kills, allowing you to spam-kill as much as you please | Toggle | Off |
 | Kill Reach | Allows you to kill players regardless of how far they are on the map | Toggle | Off |
+| Kill Cooldown Overlay | (Host only) Shows each impostor's current kill cooldown on their nametag | Toggle | Off |
 
 #### Phantom
 
@@ -122,8 +132,13 @@ MalumMenu's ESP cheats are completely client-side, and thus undetectable by anti
 | Cheat | Description | Type | Default |
 |------------|-------------|------|----|
 | Unfixable Lights | Disables lights completely (they cannot be fixed manually by players)<br>You can enable them again by clicking the button | Toggle | Off |
-| Report Body | Report any player as a dead body to start a meeting | Button |
+| Auto Report Bodies | Automatically reports dead bodies when you walk near them | Toggle | Off |
 | Close Meeting | Forcefully closes the meeting window (only for you), allowing you to move and interact with the game during meetings | Button |
+| Auto-Open Doors On Use | Automatically opens doors when you interact with them | Toggle | Off |
+| Force Teleport | (Host only) Teleport any player to a specific room or your current position | Menu |
+| Freeze Player | (Host only) Lock a player in place, preventing them from moving | Menu |
+| Force End Game | (Host only) Immediately end the game as an impostor win or crewmate win | Button |
+| Infinite Meetings | (Host only) Removes the emergency meeting call limit | Toggle | Off |
 
 #### Sabotage
 
@@ -147,6 +162,22 @@ Moreover, different sabotages can be enabled at the same time, and they even wor
 | UseVents | Allows you to use vents even if you are not an impostor or an engineer | Toggle | Off
 | KickVents | Forcefully kicks all players from vents | Button |
 | WalkInVents | Allows you to move and interact with the game even though you are inside of a vent<br>This gives you a sort of invisibility until you disable the setting and leave the vent<br>(*Some activites such as killing will forcefully make you visible again*) | Toggle | Off
+| Auto-Kick Vent Impostors | (Host only) Automatically kicks impostors from vents | Toggle | Off |
+
+## 📟 Console
+
+| Cheat | Description | Type | Default|
+|------------|-------------|------|--------|
+| Show Console | Opens an in-game console window showing real-time cheat logs | Toggle | Off |
+| Log Deaths | Logs every player death to the console as it happens | Toggle | Off |
+| Log Shapeshifts | Logs every shapeshift event to the console | Toggle | Off |
+| Log Vents | Logs every vent entry/exit to the console | Toggle | Off |
+| Kill Sound Alert | Plays an alert sound and logs a message when someone is killed | Toggle | Off |
+| Sabotage Alert | Plays an alert sound and logs a message when a sabotage activates | Toggle | Off |
+| Body Intel Logger | Logs who died, where, who was nearby at death, and who later walked past the body | Toggle | Off |
+| Chat Logger | Saves all chat messages to `BepInEx/config/MalumChat.txt` | Toggle | Off |
+| Meeting History | Opens a sub-window showing every vote cast in all previous meetings this game | Toggle | Off |
+| Meeting Timer | Displays a live countdown timer on-screen during meetings | Toggle | Off |
 
 ## 💤 Passive
 
@@ -157,6 +188,10 @@ These cheats are constantly running in the background and **cannot be disabled t
 | Free Cosmetics | Gives you access to all of the game's cosmetics for free, including:<br><br>- Hats<br>- Visors<br>- Skins<br>- Pets<br>- Nameplates<br>- Bundles<br>- Cosmicubes | Toggle | On |
 | Avoid Penalties | Removes the penalty you receive when disconnecting from games early | Toggle | On |
 | Unlock Extra Features | Unlocks many of the game's special features automatically, including:<br><br>- Freechat<br>- Friend list<br>- Custom name<br>- Online gameplay | Toggle | On |
+| Name Spoof | Set a custom display name visible to all players | Input | |
+| Anti-Bot Kick | (Host only) Automatically kicks suspected bot accounts from your lobby | Toggle | Off |
+| Copy Lobby Code on Disconnect | Copies your current lobby code to clipboard when you disconnect | Toggle | Off |
+| Spoof Date to April 1st | Tricks the game into thinking it is April Fools' Day | Toggle | Off |
 
 ## 📃 Config
 
@@ -171,7 +206,7 @@ You can change all of the following settings in `BepInEx/config/MalumMenu.cfg`
 | Privacy.HideDeviceId | When enabled, it will hide your unique deviceId from Among Us<br><br>Could **potentially** help bypass hardware bans in the future | Boolean | true |
 | Privacy.NoTelemetry | When enabled, it will stop Among Us from collecting analytics of your games using Unity Analytics and sending them to Innersloth | Boolean | true |
 | Spoofing.Level | Sets a custom player level to display to others in online games, masking your real level<br><br>**IMPORTANT**: Only integers between 0 and 4294967295 are valid. Decimal values are not accepted | String | |
-| Spoofing.Platform | Sets a different gaming platform in online lobbies to disguise your actual platform<br><br>**IMPORTANT**: You may only use platform names from this [list](https://skeld.js.org/enums/constant.Platform.html) | String | |
+| Spoofing.Platform | Sets a different gaming platform in online lobbies to disguise your actual platform<br><br>**IMPORTANT**: You may only use platform names from this [list](https://skeld.js.org/enums/platform.html) | String | |
 
 ## Other relevant features of MalumMenu:
 

--- a/src/Cheats/AvengerHandler.cs
+++ b/src/Cheats/AvengerHandler.cs
@@ -1,0 +1,120 @@
+using UnityEngine;
+
+namespace MalumMenu;
+
+public static class AvengerHandler
+{
+    private static PlayerControl _killer;
+    private static NetworkedPlayerInfo _victimData;
+    private static string _victimName;
+    private static string _killerName;
+    private static string _roomName;
+    private static float _killTime;
+    private static string _postKillAction;
+    private static bool _active;
+    private static bool _reported;
+
+    private const float DisplayTime = 8f;
+    private const float TrackWindow = 5f;
+
+    private static GUIStyle _boxStyle;
+    private static GUIStyle _labelStyle;
+    private static GUIStyle _titleStyle;
+
+    public static void OnKill(PlayerControl victim, PlayerControl killer, Vector2 bodyPos, string roomName)
+    {
+        if (!CheatToggles.avengerMode) return;
+        if (PlayerControl.LocalPlayer == null || PlayerControl.LocalPlayer.Data.IsDead) return;
+        if (killer == null || victim == null) return;
+
+        _killer       = killer;
+        _victimData   = victim.Data;
+        _victimName   = victim.Data?.PlayerName ?? "?";
+        _killerName   = killer.Data?.PlayerName ?? "?";
+        _roomName     = roomName;
+        _killTime     = Time.time;
+        _postKillAction = "Walking away...";
+        _active       = true;
+        _reported     = false;
+
+        // Teleport to body
+        try { PlayerControl.LocalPlayer.NetTransform.RpcSnapTo(bodyPos); } catch { }
+
+        // Add killer to overload and start it
+        if (!killer.AmOwner && killer.Data != null)
+        {
+            OverloadHandler.AddCustomTarget(killer.Data);
+            CheatToggles.runOverload = true;
+        }
+    }
+
+    public static void OnVent(PlayerControl pc)
+    {
+        if (!_active || _killer == null || pc == null) return;
+        if (pc.PlayerId != _killer.PlayerId) return;
+        if (Time.time - _killTime > TrackWindow) return;
+        _postKillAction = "Vented";
+    }
+
+    public static void OnShapeshift(PlayerControl pc)
+    {
+        if (!_active || _killer == null || pc == null) return;
+        if (pc.PlayerId != _killer.PlayerId) return;
+        if (Time.time - _killTime > TrackWindow) return;
+        if (_postKillAction == "Vented") return;
+        _postKillAction = "Shapeshifted";
+    }
+
+    public static void Update()
+    {
+        if (!_active) return;
+
+        float elapsed = Time.time - _killTime;
+
+        // Detect phantom vanish by polling
+        if (_killer != null && _killer.Data != null && elapsed <= TrackWindow)
+        {
+            if (_postKillAction == "Walking away..." && Utils.IsVanished(_killer.Data))
+                _postKillAction = "Vanished (Phantom)";
+        }
+
+        // Auto-report on first update tick (we're now at the body position)
+        if (!_reported && _victimData != null && PlayerControl.LocalPlayer != null && !Utils.isMeeting)
+        {
+            try { PlayerControl.LocalPlayer.CmdReportDeadBody(_victimData); } catch { }
+            _reported = true;
+        }
+
+        if (elapsed > DisplayTime)
+        {
+            _active = false;
+            _killer = null;
+            _victimData = null;
+        }
+    }
+
+    public static void DrawAlert()
+    {
+        if (!_active) return;
+
+        float remaining = DisplayTime - (Time.time - _killTime);
+
+        float w = 300f, h = 115f;
+        float x = (Screen.width - w) / 2f;
+        float y = 40f;
+
+        _boxStyle   ??= new GUIStyle(GUI.skin.box)   { fontSize = 13 };
+        _labelStyle ??= new GUIStyle(GUI.skin.label) { fontSize = 13, richText = true };
+        _titleStyle ??= new GUIStyle(GUI.skin.label) { fontSize = 15, fontStyle = FontStyle.Bold, richText = true, alignment = TextAnchor.MiddleCenter };
+
+        GUI.Box(new Rect(x - 2, y - 2, w + 4, h + 4), "", _boxStyle);
+
+        GUILayout.BeginArea(new Rect(x, y, w, h));
+        GUILayout.Label("<color=red>[!] KILL DETECTED</color>", _titleStyle);
+        GUILayout.Label($"Victim: <b>{_victimName}</b>", _labelStyle);
+        GUILayout.Label($"Killer: <b>{_killerName}</b>  |  Room: <b>{_roomName}</b>", _labelStyle);
+        GUILayout.Label($"After kill: <b>{_postKillAction}</b>", _labelStyle);
+        GUILayout.Label($"<size=10>Overload started on killer · closes in {remaining:F0}s</size>", _labelStyle);
+        GUILayout.EndArea();
+    }
+}

--- a/src/Cheats/AvengerHandler.cs
+++ b/src/Cheats/AvengerHandler.cs
@@ -9,10 +9,12 @@ public static class AvengerHandler
     private static string _victimName;
     private static string _killerName;
     private static string _roomName;
+    private static byte _killerColorId;
     private static float _killTime;
     private static string _postKillAction;
     private static bool _active;
     private static bool _reported;
+    private static bool _chatSent;
 
     private const float DisplayTime = 8f;
     private const float TrackWindow = 5f;
@@ -27,15 +29,17 @@ public static class AvengerHandler
         if (PlayerControl.LocalPlayer == null || PlayerControl.LocalPlayer.Data.IsDead) return;
         if (killer == null || victim == null) return;
 
-        _killer       = killer;
-        _victimData   = victim.Data;
-        _victimName   = victim.Data?.PlayerName ?? "?";
-        _killerName   = killer.Data?.PlayerName ?? "?";
-        _roomName     = roomName;
-        _killTime     = Time.time;
+        _killer         = killer;
+        _victimData     = victim.Data;
+        _victimName     = victim.Data?.PlayerName ?? "?";
+        _killerName     = killer.Data?.PlayerName ?? "?";
+        _killerColorId  = (byte)(killer.Data?.DefaultOutfit?.ColorId ?? 0);
+        _roomName       = roomName;
+        _killTime       = Time.time;
         _postKillAction = "Walking away...";
-        _active       = true;
-        _reported     = false;
+        _active         = true;
+        _reported       = false;
+        _chatSent       = false;
 
         // Teleport to body
         try { PlayerControl.LocalPlayer.NetTransform.RpcSnapTo(bodyPos); } catch { }
@@ -78,11 +82,28 @@ public static class AvengerHandler
                 _postKillAction = "Vanished (Phantom)";
         }
 
-        // Auto-report on first update tick (we're now at the body position)
+        // Auto-report and send chat message on first update tick
         if (!_reported && _victimData != null && PlayerControl.LocalPlayer != null && !Utils.isMeeting)
         {
             try { PlayerControl.LocalPlayer.CmdReportDeadBody(_victimData); } catch { }
             _reported = true;
+        }
+
+        // Send chat once the meeting is active so the message lands in meeting chat
+        if (_reported && !_chatSent && Utils.isMeeting && PlayerControl.LocalPlayer != null)
+        {
+            try
+            {
+                string colorName = _killerColorId < Palette.ColorNames.Length
+                    ? DestroyableSingleton<TranslationController>.Instance
+                        .GetString(Palette.ColorNames[_killerColorId], Il2CppSystem.Array.Empty<Il2CppSystem.Object>())
+                        .ToUpperInvariant()
+                    : _killerColorId.ToString();
+                string msg = $"{colorName} KILLED IN FRONT OF ME IN {_roomName.ToUpperInvariant()}";
+                PlayerControl.LocalPlayer.RpcSendChat(msg);
+                _chatSent = true; // only mark sent on success
+            }
+            catch { }
         }
 
         if (elapsed > DisplayTime)

--- a/src/Cheats/BodyIntelHandler.cs
+++ b/src/Cheats/BodyIntelHandler.cs
@@ -26,11 +26,15 @@ public static class BodyIntelHandler
     public static void OnMurder(PlayerControl victim, PlayerControl killer)
     {
         if (victim == null || victim.Data == null) return;
-        if (!CheatToggles.bodyIntelLogger && !CheatToggles.autoReport) return;
 
         var room     = Utils.GetRoomFromPosition(victim.GetTruePosition());
         var roomName = room != null ? room.RoomId.ToString() : "Unknown";
         var pos      = victim.GetTruePosition();
+
+        // Always notify avenger mode regardless of other logger toggles
+        AvengerHandler.OnKill(victim, killer, pos, roomName);
+
+        if (!CheatToggles.bodyIntelLogger && !CheatToggles.autoReport) return;
 
         var victimRoom = Utils.GetRoomFromPosition(pos);
 

--- a/src/Cheats/BodyIntelHandler.cs
+++ b/src/Cheats/BodyIntelHandler.cs
@@ -32,12 +32,20 @@ public static class BodyIntelHandler
         var roomName = room != null ? room.RoomId.ToString() : "Unknown";
         var pos      = victim.GetTruePosition();
 
+        var victimRoom = Utils.GetRoomFromPosition(pos);
+
         var nearby = new List<string>();
         foreach (var p in PlayerControl.AllPlayerControls)
         {
             if (p == null || p == victim || p == killer || p.Data == null || p.Data.IsDead) continue;
-            if (Vector2.Distance(p.GetTruePosition(), pos) <= NearRadius)
-                nearby.Add(p.Data.PlayerName);
+            if (Vector2.Distance(p.GetTruePosition(), pos) > NearRadius) continue;
+            // Only count players confirmed in the same room — prevents adjacent-room false positives
+            if (victimRoom != null)
+            {
+                var pRoom = Utils.GetRoomFromPosition(p.GetTruePosition());
+                if (pRoom == null || pRoom.RoomId != victimRoom.RoomId) continue;
+            }
+            nearby.Add(p.Data.PlayerName);
         }
 
         var record = new BodyRecord
@@ -80,10 +88,19 @@ public static class BodyIntelHandler
 
                 if (!_loggedPass.TryGetValue(idx, out var already)) { already = new(); _loggedPass[idx] = already; }
 
+                var bodyPos  = (Vector2)bodyObj.transform.position;
+                var bodyRoom = Utils.GetRoomFromPosition(bodyPos);
+
                 foreach (var p in PlayerControl.AllPlayerControls)
                 {
                     if (p == null || p.Data == null || p.Data.IsDead) continue;
-                    if (Vector2.Distance(p.GetTruePosition(), (Vector2)bodyObj.transform.position) > NearRadius) continue;
+                    if (Vector2.Distance(p.GetTruePosition(), bodyPos) > NearRadius) continue;
+                    // Reject players in a different room — prevents door/wall false positives
+                    if (bodyRoom != null)
+                    {
+                        var pRoom = Utils.GetRoomFromPosition(p.GetTruePosition());
+                        if (pRoom == null || pRoom.RoomId != bodyRoom.RoomId) continue;
+                    }
                     string name = p.Data.PlayerName;
                     if (already.Add(name))
                     {

--- a/src/Cheats/BodyIntelHandler.cs
+++ b/src/Cheats/BodyIntelHandler.cs
@@ -1,0 +1,126 @@
+using System.Collections.Generic;
+using UnityEngine;
+
+namespace MalumMenu;
+
+public static class BodyIntelHandler
+{
+    private const float NearRadius       = 3.5f;
+    private const float AutoReportRadius = 1.8f;
+
+    public struct BodyRecord
+    {
+        public string       VictimName;
+        public string       KillerName;
+        public string       RoomName;
+        public Vector2      Position;
+        public List<string> NearbyAtDeath;
+        public List<string> PassedBy;
+    }
+
+    public static readonly List<BodyRecord> Records = new();
+
+    // Set<playerName> per record index, tracks who has already been logged as passing
+    private static readonly Dictionary<int, HashSet<string>> _loggedPass = new();
+
+    public static void OnMurder(PlayerControl victim, PlayerControl killer)
+    {
+        if (victim == null || victim.Data == null) return;
+        if (!CheatToggles.bodyIntelLogger && !CheatToggles.autoReport) return;
+
+        var room     = Utils.GetRoomFromPosition(victim.GetTruePosition());
+        var roomName = room != null ? room.RoomId.ToString() : "Unknown";
+        var pos      = victim.GetTruePosition();
+
+        var nearby = new List<string>();
+        foreach (var p in PlayerControl.AllPlayerControls)
+        {
+            if (p == null || p == victim || p == killer || p.Data == null || p.Data.IsDead) continue;
+            if (Vector2.Distance(p.GetTruePosition(), pos) <= NearRadius)
+                nearby.Add(p.Data.PlayerName);
+        }
+
+        var record = new BodyRecord
+        {
+            VictimName    = victim.Data.PlayerName,
+            KillerName    = killer?.Data?.PlayerName ?? "Unknown",
+            RoomName      = roomName,
+            Position      = pos,
+            NearbyAtDeath = nearby,
+            PassedBy      = new(nearby) // seed with anyone nearby at time of death
+        };
+
+        Records.Add(record);
+        _loggedPass[Records.Count - 1] = new HashSet<string>(nearby);
+
+        if (CheatToggles.bodyIntelLogger)
+        {
+            ConsoleUI.Log($"[BodyIntel] {record.VictimName} killed by {record.KillerName} in {roomName}");
+            if (nearby.Count > 0)
+                ConsoleUI.Log($"[BodyIntel] Nearby at death: {string.Join(", ", nearby)}");
+        }
+    }
+
+    public static void Update()
+    {
+        if (!Utils.isShip || !Utils.isInGame) return;
+
+        var bodies = GameObject.FindGameObjectsWithTag("DeadBody");
+
+        // Track passers-by
+        if (CheatToggles.bodyIntelLogger)
+        {
+            foreach (var bodyObj in bodies)
+            {
+                var dead = bodyObj.GetComponent<DeadBody>();
+                if (dead == null || dead.Reported) continue;
+
+                int idx = FindRecord((Vector2)bodyObj.transform.position);
+                if (idx < 0) continue;
+
+                if (!_loggedPass.TryGetValue(idx, out var already)) { already = new(); _loggedPass[idx] = already; }
+
+                foreach (var p in PlayerControl.AllPlayerControls)
+                {
+                    if (p == null || p.Data == null || p.Data.IsDead) continue;
+                    if (Vector2.Distance(p.GetTruePosition(), (Vector2)bodyObj.transform.position) > NearRadius) continue;
+                    string name = p.Data.PlayerName;
+                    if (already.Add(name))
+                    {
+                        Records[idx].PassedBy.Add(name);
+                        ConsoleUI.Log($"[BodyIntel] {name} passed body of {Records[idx].VictimName} in {Records[idx].RoomName}");
+                    }
+                }
+            }
+        }
+
+        // Auto Report
+        if (CheatToggles.autoReport && PlayerControl.LocalPlayer != null
+            && !PlayerControl.LocalPlayer.Data.IsDead && !Utils.isMeeting)
+        {
+            foreach (var bodyObj in bodies)
+            {
+                var dead = bodyObj.GetComponent<DeadBody>();
+                if (dead == null || dead.Reported) continue;
+                if (Vector2.Distance(PlayerControl.LocalPlayer.GetTruePosition(), (Vector2)bodyObj.transform.position) <= AutoReportRadius)
+                {
+                    try { PlayerControl.LocalPlayer.CmdReportDeadBody(GameData.Instance.GetPlayerById(dead.ParentId)); } catch { }
+                    break;
+                }
+            }
+        }
+    }
+
+    private static int FindRecord(Vector2 bodyPos)
+    {
+        for (int i = Records.Count - 1; i >= 0; i--)
+            if (Vector2.Distance(Records[i].Position, bodyPos) < 1f) return i;
+        return -1;
+    }
+
+    public static void Clear()
+    {
+        Records.Clear();
+        _loggedPass.Clear();
+    }
+}

--- a/src/Cheats/FootprintHandler.cs
+++ b/src/Cheats/FootprintHandler.cs
@@ -1,0 +1,153 @@
+using System.Collections.Generic;
+using UnityEngine;
+
+namespace MalumMenu;
+
+public static class FootprintHandler
+{
+    // --- Footprints ---
+    private const float FootprintInterval = 0.5f;
+    private const float FootprintFade     = 8f;
+    private const int   MaxPerPlayer      = 20;
+
+    private struct Footprint { public Vector3 World; public float Born; public Color Color; }
+    private static readonly Dictionary<byte, List<Footprint>> _prints     = new();
+    private static readonly Dictionary<byte, float>           _lastSample = new();
+    private static Texture2D _dot;
+
+    // --- Player Trail (LocalPlayer only) ---
+    private const int   TrailMax      = 50;
+    private const float TrailInterval = 0.04f;
+    private static GameObject    _trailObj;
+    private static LineRenderer  _trailLr;
+    private static readonly List<Vector3> _trailPts = new();
+    private static float _lastTrailT;
+
+    // --- Kill Range Indicator ---
+    private const int CircleSegs = 48;
+    private static GameObject   _rangeObj;
+    private static LineRenderer _rangeLr;
+
+    public static void Update()
+    {
+        if (!Utils.isShip) { Clear(); return; }
+        float now = Time.time;
+
+        // Footprints
+        if (CheatToggles.footprints)
+        {
+            foreach (var player in PlayerControl.AllPlayerControls)
+            {
+                if (player == null || player.Data == null || player.Data.IsDead) continue;
+                byte pid = player.PlayerId;
+                if (!_lastSample.TryGetValue(pid, out float last) || now - last >= FootprintInterval)
+                {
+                    _lastSample[pid] = now;
+                    if (!_prints.TryGetValue(pid, out var list)) { list = new(); _prints[pid] = list; }
+                    list.Add(new Footprint { World = player.GetTruePosition(), Born = now, Color = player.Data.Color });
+                    if (list.Count > MaxPerPlayer) list.RemoveAt(0);
+                }
+            }
+        }
+
+        // Player Trail
+        if (CheatToggles.playerTrail && PlayerControl.LocalPlayer != null)
+        {
+            if (_trailObj == null)
+            {
+                _trailObj = new GameObject("MM_Trail");
+                _trailLr  = _trailObj.AddComponent<LineRenderer>();
+                _trailLr.useWorldSpace = true;
+                _trailLr.material      = DestroyableSingleton<HatManager>.Instance.PlayerMaterial;
+                _trailLr.SetWidth(0.08f, 0.01f);
+                _trailPts.Clear();
+            }
+
+            if (now - _lastTrailT >= TrailInterval)
+            {
+                _lastTrailT = now;
+                _trailPts.Add(PlayerControl.LocalPlayer.GetTruePosition());
+                if (_trailPts.Count > TrailMax) _trailPts.RemoveAt(0);
+            }
+
+            _trailLr.positionCount = _trailPts.Count;
+            var c = PlayerControl.LocalPlayer.Data?.Color ?? Color.white;
+            _trailLr.startColor = new Color(c.r, c.g, c.b, 0.9f);
+            _trailLr.endColor   = new Color(c.r, c.g, c.b, 0f);
+            for (int i = 0; i < _trailPts.Count; i++) _trailLr.SetPosition(i, _trailPts[i]);
+        }
+        else if (_trailObj != null)
+        {
+            Object.Destroy(_trailObj); _trailObj = null; _trailPts.Clear();
+        }
+
+        // Kill Range Indicator
+        if (CheatToggles.killRangeIndicator && Utils.isInGame && PlayerControl.LocalPlayer != null)
+        {
+            if (_rangeObj == null)
+            {
+                _rangeObj = new GameObject("MM_KillRange");
+                _rangeLr  = _rangeObj.AddComponent<LineRenderer>();
+                _rangeLr.useWorldSpace = true;
+                _rangeLr.material      = DestroyableSingleton<HatManager>.Instance.PlayerMaterial;
+                _rangeLr.SetWidth(0.04f, 0.04f);
+                _rangeLr.loop = true;
+                _rangeLr.positionCount = CircleSegs;
+            }
+
+            float radius = GameManager.Instance.LogicOptions.GetKillDistance();
+            var   center = (Vector2)PlayerControl.LocalPlayer.transform.position;
+            for (int i = 0; i < CircleSegs; i++)
+            {
+                float a = 2f * Mathf.PI * i / CircleSegs;
+                _rangeLr.SetPosition(i, new Vector3(center.x + Mathf.Cos(a) * radius, center.y + Mathf.Sin(a) * radius, -1f));
+            }
+            var rc = new Color(1f, 0.2f, 0.2f, 0.55f);
+            _rangeLr.startColor = rc;
+            _rangeLr.endColor   = rc;
+        }
+        else if (_rangeObj != null)
+        {
+            Object.Destroy(_rangeObj); _rangeObj = null;
+        }
+    }
+
+    // Called from OnGUI to draw footprint dots
+    public static void DrawGUI()
+    {
+        if (!CheatToggles.footprints || CheatToggles.streamerMode || Camera.main == null) return;
+
+        if (_dot == null)
+        {
+            _dot = new Texture2D(1, 1);
+            _dot.SetPixel(0, 0, Color.white);
+            _dot.Apply();
+        }
+
+        float now = Time.time;
+        foreach (var kvp in _prints)
+        {
+            foreach (var fp in kvp.Value)
+            {
+                float age = now - fp.Born;
+                if (age > FootprintFade) continue;
+                var sp = Camera.main.WorldToScreenPoint(fp.World);
+                if (sp.z < 0f) continue;
+                float alpha = (1f - age / FootprintFade) * 0.8f;
+                GUI.color = new Color(fp.Color.r, fp.Color.g, fp.Color.b, alpha);
+                GUI.DrawTexture(new Rect(sp.x - 5f, Screen.height - sp.y - 5f, 10f, 10f), _dot);
+            }
+        }
+        GUI.color = Color.white;
+    }
+
+    public static void Clear()
+    {
+        _prints.Clear();
+        _lastSample.Clear();
+        _trailPts.Clear();
+        _lastTrailT = 0f;
+        if (_trailObj != null) { Object.Destroy(_trailObj); _trailObj = null; }
+        if (_rangeObj != null) { Object.Destroy(_rangeObj); _rangeObj = null; }
+    }
+}

--- a/src/Cheats/FootprintHandler.cs
+++ b/src/Cheats/FootprintHandler.cs
@@ -53,7 +53,7 @@ public static class FootprintHandler
         // Player Trail
         if (CheatToggles.playerTrail && PlayerControl.LocalPlayer != null)
         {
-            if (_trailObj == null)
+            if (_trailObj == null && DestroyableSingleton<HatManager>.Instance != null)
             {
                 _trailObj = new GameObject("MM_Trail");
                 _trailLr  = _trailObj.AddComponent<LineRenderer>();
@@ -84,7 +84,7 @@ public static class FootprintHandler
         // Kill Range Indicator
         if (CheatToggles.killRangeIndicator && Utils.isInGame && PlayerControl.LocalPlayer != null)
         {
-            if (_rangeObj == null)
+            if (_rangeObj == null && DestroyableSingleton<HatManager>.Instance != null)
             {
                 _rangeObj = new GameObject("MM_KillRange");
                 _rangeLr  = _rangeObj.AddComponent<LineRenderer>();
@@ -147,7 +147,7 @@ public static class FootprintHandler
         _lastSample.Clear();
         _trailPts.Clear();
         _lastTrailT = 0f;
-        if (_trailObj != null) { Object.Destroy(_trailObj); _trailObj = null; }
-        if (_rangeObj != null) { Object.Destroy(_rangeObj); _rangeObj = null; }
+        if (_trailObj != null) { Object.Destroy(_trailObj); _trailObj = null; _trailLr = null; }
+        if (_rangeObj != null) { Object.Destroy(_rangeObj); _rangeObj = null; _rangeLr = null; }
     }
 }

--- a/src/Cheats/ForceTeleportHandler.cs
+++ b/src/Cheats/ForceTeleportHandler.cs
@@ -1,0 +1,143 @@
+using System;
+using System.Collections.Generic;
+using UnityEngine;
+
+namespace MalumMenu;
+
+public static class ForceTeleportHandler
+{
+    public static readonly Dictionary<MapNames, List<(string Name, Vector2 Position)>> MapRooms = new()
+    {
+        [MapNames.Skeld] = new()
+        {
+            ("Cafeteria",      new(0.7f,   4.2f)),
+            ("Weapons",        new(8.7f,   3.1f)),
+            ("O2",             new(7.2f,   1.0f)),
+            ("Navigation",     new(17.2f, -4.8f)),
+            ("Shields",        new(9.4f, -10.4f)),
+            ("Communications", new(0.0f, -15.1f)),
+            ("Storage",        new(0.4f, -16.2f)),
+            ("Admin",          new(0.4f,  -7.1f)),
+            ("Electrical",     new(-7.0f, -9.8f)),
+            ("Lower Engine",   new(-15.0f,-13.6f)),
+            ("Reactor",        new(-20.7f, -6.7f)),
+            ("Upper Engine",   new(-15.3f, -2.4f)),
+            ("Security",       new(-13.2f, -5.7f)),
+            ("Medbay",         new(-7.0f,  -4.6f)),
+        },
+        [MapNames.MiraHQ] = new()
+        {
+            ("Cafeteria",      new(23.5f, 23.3f)),
+            ("Balcony",        new(24.5f, 19.5f)),
+            ("Admin",          new(21.5f, 19.0f)),
+            ("Locker Room",    new(7.5f,   1.5f)),
+            ("Launchpad",      new(2.5f,   2.0f)),
+            ("Greenhouse",     new(17.5f, 22.5f)),
+            ("Office",         new(15.5f, 24.0f)),
+            ("Laboratory",     new(17.5f, 14.0f)),
+            ("Medbay",         new(15.5f,  8.5f)),
+            ("Storage",        new(7.5f,  11.5f)),
+            ("Communications", new(13.0f, 12.5f)),
+            ("Reactor",        new(2.5f,  11.5f)),
+        },
+        [MapNames.Polus] = new()
+        {
+            ("Office",         new(16.5f, -15.0f)),
+            ("Headquarters",   new(9.5f,   -7.0f)),
+            ("Admin",          new(20.5f, -24.5f)),
+            ("Electrical",     new(7.0f,  -18.5f)),
+            ("O2",             new(4.0f,   -7.5f)),
+            ("Communications", new(12.0f, -18.5f)),
+            ("Weapons",        new(14.0f, -11.0f)),
+            ("Security",       new(1.5f,  -11.5f)),
+            ("Medbay",         new(36.5f,  -7.0f)),
+            ("Storage",        new(21.5f, -11.5f)),
+            ("Laboratory",     new(31.0f,  -7.5f)),
+            ("Specimen Room",  new(36.0f, -20.5f)),
+            ("Drill",          new(27.0f, -18.0f)),
+            ("Dropship",       new(9.0f,  -11.5f)),
+            ("Boiler Room",    new(3.5f,  -22.0f)),
+        },
+        [MapNames.Airship] = new()
+        {
+            ("Brig",           new(22.0f,  8.0f)),
+            ("Engine",         new(5.0f,   0.0f)),
+            ("Kitchen",        new(27.0f, -3.0f)),
+            ("Gap Room",       new(13.5f, -1.0f)),
+            ("Cargo Bay",      new(15.0f, -7.0f)),
+            ("Communications", new(14.5f,  3.0f)),
+            ("Main Hall",      new(19.5f,  3.0f)),
+            ("Meeting Room",   new(10.5f, 14.0f)),
+            ("Lounge",         new(33.5f, 10.0f)),
+            ("Records",        new(21.0f, 14.0f)),
+            ("Showers",        new(28.0f, 14.0f)),
+            ("Vault",          new(12.5f, 14.0f)),
+            ("Cockpit",        new(-2.0f,  0.5f)),
+            ("Medical",        new(-4.5f,  3.0f)),
+            ("Armory",         new(10.0f,-11.0f)),
+            ("Electrical",     new(13.0f,-13.0f)),
+            ("Viewing Deck",   new(27.0f,-13.0f)),
+            ("Security",       new(7.0f,  -7.0f)),
+            ("Reactor",        new(1.5f,  -6.5f)),
+        },
+        [MapNames.Fungle] = new()
+        {
+            ("Cafeteria",      new(2.0f,   8.0f)),
+            ("Kitchen",        new(-10.5f, 4.5f)),
+            ("Upper Engine",   new(-16.5f, 8.5f)),
+            ("Launch Pad",     new(-18.5f, 3.5f)),
+            ("Comms",          new(-15.5f,-2.5f)),
+            ("Storage",        new(-3.5f, -4.5f)),
+            ("Mining Pit",     new(-7.0f,-12.5f)),
+            ("Jungle",         new(4.5f, -12.0f)),
+            ("Reactor",        new(-16.5f,-9.5f)),
+            ("Lookout",        new(10.0f, -5.5f)),
+            ("Lab",            new(17.0f, -7.5f)),
+            ("Medbay",         new(12.0f,  3.5f)),
+            ("The Highlands",  new(11.0f, 12.0f)),
+        },
+    };
+
+    public static List<(string Name, Vector2 Position)> GetRoomsForCurrentMap()
+    {
+        var mapName = (MapNames)Utils.GetCurrentMapID();
+        return MapRooms.TryGetValue(mapName, out var rooms) ? rooms : new();
+    }
+
+    public static void TeleportPlayer(PlayerControl target, Vector2 destination)
+    {
+        if (!Utils.isHost) return;
+        if (target == null || target.Data == null) return;
+
+        if (target.Data.Disconnected)
+        {
+            ConsoleUI.Log("[ForceTeleport] Cannot teleport a disconnected player");
+            return;
+        }
+        if (target.Data.IsDead)
+        {
+            ConsoleUI.Log("[ForceTeleport] Cannot teleport a dead player");
+            return;
+        }
+        if (target.inVent)
+        {
+            ConsoleUI.Log("[ForceTeleport] Cannot teleport a player inside a vent");
+            return;
+        }
+        if (Utils.isMeeting)
+        {
+            ConsoleUI.Log("[ForceTeleport] Cannot teleport during a meeting");
+            return;
+        }
+
+        try
+        {
+            target.NetTransform.RpcSnapTo(destination);
+            ConsoleUI.Log($"[ForceTeleport] Teleported {target.Data.PlayerName} to ({destination.x:F1}, {destination.y:F1})");
+        }
+        catch (Exception ex)
+        {
+            ConsoleUI.Log($"[ForceTeleport] RPC failed: {ex.Message}");
+        }
+    }
+}

--- a/src/Cheats/MalumCheats.cs
+++ b/src/Cheats/MalumCheats.cs
@@ -3,6 +3,7 @@ using AmongUs.GameOptions;
 using AmongUs.InnerNet.GameDataMessages;
 using UnityEngine;
 using Il2CppInterop.Runtime.InteropTypes.Arrays;
+using BepInEx.Unity.IL2CPP.Utils;
 
 namespace MalumMenu;
 public static class MalumCheats
@@ -25,7 +26,7 @@ public static class MalumCheats
             DestroyableSingleton<HudManager>.Instance.StartCoroutine(DestroyableSingleton<HudManager>.Instance.CoFadeFullScreen(Color.black, Color.clear, 0.2f, false));
             PlayerControl.LocalPlayer.SetKillTimer(GameManager.Instance.LogicOptions.GetKillCooldown());
             ShipStatus.Instance.EmergencyCooldown = GameManager.Instance.LogicOptions.GetEmergencyCooldown();
-            Camera.main.GetComponent<FollowerCamera>().Locked = false;
+            if (Camera.main != null) Camera.main.GetComponent<FollowerCamera>().Locked = false;
             DestroyableSingleton<HudManager>.Instance.SetMapButtonEnabled(true);
             DestroyableSingleton<HudManager>.Instance.SetHudActive(true);
             ControllerManager.Instance.CloseAndResetAll();
@@ -269,10 +270,9 @@ public static class MalumCheats
             // Kill all players by sending a successful MurderPlayer RPC call
             foreach (var player in PlayerControl.AllPlayerControls)
             {
+                if (player == null || player.Data == null || player.Data.Role == null) continue;
                 if (player.Data.Role.TeamType == RoleTeamTypes.Crewmate)
-                {
                     Utils.MurderPlayer(player, MurderResultFlags.Succeeded);
-                }
             }
         }
 
@@ -292,10 +292,9 @@ public static class MalumCheats
             // Kill all players by sending a successful MurderPlayer RPC call
             foreach (var player in PlayerControl.AllPlayerControls)
             {
+                if (player == null || player.Data == null || player.Data.Role == null) continue;
                 if (player.Data.Role.TeamType == RoleTeamTypes.Impostor)
-                {
                     Utils.MurderPlayer(player, MurderResultFlags.Succeeded);
-                }
             }
         }
 
@@ -462,6 +461,85 @@ public static class MalumCheats
             GameManager.Instance.RpcEndGame(reason, false);
         }
         catch { }
+    }
+
+    // Returns whether the smart-kill combo can fire right now, plus a human-readable reason string.
+    public static (bool canExecute, string reason) SmartKillStatus()
+    {
+        if (!Utils.isHost || !Utils.isInGame) return (false, "Requires host");
+        if (!Utils.isShip) return (false, "Not in ship");
+        var localData = PlayerControl.LocalPlayer?.Data;
+        if (localData == null || localData.IsDead) return (false, "You are dead");
+        if (localData.Role?.TeamType != RoleTeamTypes.Impostor) return (false, "Not impostor");
+
+        var myRoom = Utils.GetRoomFromPosition(PlayerControl.LocalPlayer.GetTruePosition());
+        if (myRoom == null) return (false, "Unknown room");
+
+        PlayerControl target = null;
+        int othersInRoom = 0;
+        foreach (var p in PlayerControl.AllPlayerControls)
+        {
+            if (p == null || p.AmOwner || p.Data == null || p.Data.IsDead || p.Data.Disconnected) continue;
+            var pRoom = Utils.GetRoomFromPosition(p.GetTruePosition());
+            if (pRoom?.RoomId != myRoom.RoomId) continue;
+            othersInRoom++;
+            target = p;
+        }
+
+        if (othersInRoom == 0) return (false, "No target in room");
+        if (othersInRoom > 1) return (false, $"{othersInRoom} others in room");
+
+        // Vent-camper check: reject if any third player is within 3.5 u of a vent in this room
+        foreach (var vent in ShipStatus.Instance.AllVents)
+        {
+            var ventRoom = Utils.GetRoomFromPosition((Vector2)vent.transform.position);
+            if (ventRoom?.RoomId != myRoom.RoomId) continue;
+            foreach (var p in PlayerControl.AllPlayerControls)
+            {
+                if (p == null || p.AmOwner || p == target || p.Data == null || p.Data.IsDead) continue;
+                if (Vector2.Distance(p.GetTruePosition(), (Vector2)vent.transform.position) < 3.5f)
+                    return (false, "Witness near vent");
+            }
+        }
+
+        return (true, $"Target: {target.Data.PlayerName}");
+    }
+
+    // Combo: close current room doors → murder the lone target → vent out.
+    public static void SmartKillCombo()
+    {
+        var (canExecute, reason) = SmartKillStatus();
+        if (!canExecute) { ConsoleUI.Log($"[SmartKill] {reason}"); return; }
+
+        var myRoom = Utils.GetRoomFromPosition(PlayerControl.LocalPlayer.GetTruePosition());
+
+        PlayerControl target = null;
+        foreach (var p in PlayerControl.AllPlayerControls)
+        {
+            if (p == null || p.AmOwner || p.Data == null || p.Data.IsDead || p.Data.Disconnected) continue;
+            if (Utils.GetRoomFromPosition(p.GetTruePosition())?.RoomId == myRoom.RoomId) { target = p; break; }
+        }
+        if (target == null) return;
+
+        DoorsHandler.CloseDoorsInRoom(myRoom.RoomId);
+        Utils.MurderPlayer(target, MurderResultFlags.Succeeded);
+
+        // Snap to nearest vent and enter it
+        Vent nearest = null;
+        float minDist = float.MaxValue;
+        foreach (var vent in ShipStatus.Instance.AllVents)
+        {
+            float d = Vector2.Distance(PlayerControl.LocalPlayer.GetTruePosition(), (Vector2)vent.transform.position);
+            if (d < minDist) { minDist = d; nearest = vent; }
+        }
+
+        if (nearest != null)
+        {
+            PlayerControl.LocalPlayer.NetTransform.RpcSnapTo(nearest.transform.position);
+            AmongUsClient.Instance.StartCoroutine(Utils.DelayedEnterVent(nearest.Id));
+        }
+
+        ConsoleUI.Log($"[SmartKill] Executed on {target.Data.PlayerName} in {myRoom.RoomId}");
     }
 
     public static void StopShipAnimCheats()

--- a/src/Cheats/MalumCheats.cs
+++ b/src/Cheats/MalumCheats.cs
@@ -421,6 +421,49 @@ public static class MalumCheats
         }
     }
 
+    public static void BlinkCheat()
+    {
+        if (!CheatToggles.blink || PlayerControl.LocalPlayer?.NetTransform == null || Camera.main == null) return;
+        if (Input.GetKeyDown(KeyCode.Mouse2))
+            PlayerControl.LocalPlayer.NetTransform.RpcSnapTo(Camera.main.ScreenToWorldPoint(Input.mousePosition));
+    }
+
+    public static void VisionBoostCheat()
+    {
+        if (!CheatToggles.visionBoost || !Utils.isInGame) return;
+        try
+        {
+            // Override local options light multipliers without broadcasting (no RpcSyncSettings call)
+            GameOptionsManager.Instance.currentGameOptions.SetFloat(FloatOptionNames.CrewLightMod,     10f);
+            GameOptionsManager.Instance.currentGameOptions.SetFloat(FloatOptionNames.ImpostorLightMod, 10f);
+        }
+        catch { }
+    }
+
+    private static bool _wasSabotageActive;
+    public static void SabotageAlertCheat()
+    {
+        if (!Utils.isShip) { _wasSabotageActive = false; return; }
+        bool now = Utils.isAnySabotageActive;
+        if (CheatToggles.sabotageAlert && now && !_wasSabotageActive)
+        {
+            ConsoleUI.Log("[!] Sabotage activated!");
+            try { SoundManager.Instance.PlaySound(DestroyableSingleton<HudManager>.Instance.Chat.messageSound, false); } catch { }
+        }
+        _wasSabotageActive = now;
+    }
+
+    public static void ForceEndGameCheat(bool impostorsWin)
+    {
+        if (!Utils.isHost || !Utils.isInGame) return;
+        try
+        {
+            var reason = impostorsWin ? GameOverReason.ImpostorsByKill : GameOverReason.CrewmatesByTask;
+            GameManager.Instance.RpcEndGame(reason, false);
+        }
+        catch { }
+    }
+
     public static void StopShipAnimCheats()
     {
         CheatToggles.animShields = false;
@@ -434,5 +477,6 @@ public static class MalumCheats
 
         _isCamsAnimActive = false;
         _isScanAnimActive = false;
+        _wasSabotageActive = false;
     }
 }

--- a/src/Cheats/MalumCheats.cs
+++ b/src/Cheats/MalumCheats.cs
@@ -466,7 +466,7 @@ public static class MalumCheats
     // Returns whether the smart-kill combo can fire right now, plus a human-readable reason string.
     public static (bool canExecute, string reason) SmartKillStatus()
     {
-        if (!Utils.isHost || !Utils.isInGame) return (false, "Requires host");
+        if (!Utils.isInGame) return (false, "Not in game");
         if (!Utils.isShip) return (false, "Not in ship");
         var localData = PlayerControl.LocalPlayer?.Data;
         if (localData == null || localData.IsDead) return (false, "You are dead");

--- a/src/Cheats/MalumESP.cs
+++ b/src/Cheats/MalumESP.cs
@@ -25,7 +25,9 @@ public static class MalumESP
         // Fullbright is automatically activated when zooming out, spectating other players, or "freecamming"
         // This is done to avoid issues with shadows
 
-        return CheatToggles.noShadows || Camera.main.orthographicSize > 3f || Camera.main.gameObject.GetComponent<FollowerCamera>().Target != PlayerControl.LocalPlayer;
+        if (Camera.main == null) return false;
+        var follower = Camera.main.gameObject.GetComponent<FollowerCamera>();
+        return CheatToggles.noShadows || Camera.main.orthographicSize > 3f || (follower != null && follower.Target != PlayerControl.LocalPlayer);
     }
 
     public static void ZoomOut(HudManager hudManager)
@@ -180,34 +182,30 @@ public static class MalumESP
         if (CheatToggles.freecam)
         {
             // Completely disable FollowerCamera
+            if (Camera.main == null || PlayerControl.LocalPlayer == null) return;
+
             if (!_freecamActive)
             {
-
-                Camera.main.gameObject.GetComponent<FollowerCamera>().enabled = false;
-                Camera.main.gameObject.GetComponent<FollowerCamera>().Target = null;
-
+                var fc = Camera.main.gameObject.GetComponent<FollowerCamera>();
+                if (fc != null) { fc.enabled = false; fc.Target = null; }
                 _freecamActive = true;
-
             }
 
-            // Prevent the player from moving while in freecam
             PlayerControl.LocalPlayer.moveable = false;
 
-            // Get keyboard input
             var movement = new Vector3(Input.GetAxis("Horizontal"), Input.GetAxis("Vertical"), 0.0f);
-
-            // Change the camera's position depending on the keyboard input
-            // Speed: 10f
             Camera.main.transform.position = Camera.main.transform.position + movement * 10f * Time.deltaTime;
 
         }
         else
         {
-            // Re-enable FollowerCamera & movement once freecam is disabled
             if (!_freecamActive) return;
-            PlayerControl.LocalPlayer.moveable = true;
-            Camera.main.gameObject.GetComponent<FollowerCamera>().enabled = true;
-            Camera.main.gameObject.GetComponent<FollowerCamera>().SetTarget(PlayerControl.LocalPlayer);
+            if (Camera.main != null && PlayerControl.LocalPlayer != null)
+            {
+                PlayerControl.LocalPlayer.moveable = true;
+                var fc = Camera.main.gameObject.GetComponent<FollowerCamera>();
+                if (fc != null) { fc.enabled = true; fc.SetTarget(PlayerControl.LocalPlayer); }
+            }
             _freecamActive = false;
         }
     }

--- a/src/Cheats/MalumESP.cs
+++ b/src/Cheats/MalumESP.cs
@@ -81,6 +81,7 @@ public static class MalumESP
     {
         try
         {
+            if (CheatToggles.streamerMode) return;
             foreach (var playerState in meetingHud.playerStates)
             {
                 // Fetch the NetworkedPlayerInfo of each playerState
@@ -116,7 +117,21 @@ public static class MalumESP
     {
         try
         {
-            playerPhysics.myPlayer.cosmetics.SetName(Utils.GetNameTag(playerPhysics.myPlayer.Data, playerPhysics.myPlayer.CurrentOutfit.PlayerName));
+            if (CheatToggles.streamerMode) return;
+
+            var tag = Utils.GetNameTag(playerPhysics.myPlayer.Data, playerPhysics.myPlayer.CurrentOutfit.PlayerName);
+
+            // Kill cooldown overlay: append remaining CD above impostors' heads (host only, has the data)
+            if (CheatToggles.showKillCdOverlay && Utils.isHost && playerPhysics.myPlayer.Data.Role?.IsImpostor == true)
+            {
+                float cd = Mathf.CeilToInt(playerPhysics.myPlayer.killTimer);
+                if (cd > 0f) tag = $"<size=70%><color=#ff4444>🗡 {cd}s</color></size>\n{tag}";
+            }
+
+            // Player notes suffix
+            tag += PlayerNotesUI.GetNoteSuffix(playerPhysics.myPlayer.PlayerId);
+
+            playerPhysics.myPlayer.cosmetics.SetName(tag);
             // Move the nameText up to prevent it overlapping with colorblind text
             if (CheatToggles.seeRoles && CheatToggles.seePlayerInfo)
             {

--- a/src/Cheats/MalumPPMCheats.cs
+++ b/src/Cheats/MalumPPMCheats.cs
@@ -23,6 +23,8 @@ public static class MalumPPMCheats
     private static Vector2 _frozenPos;
     private static RoleTypes? _oldRole = null;
 
+    public static void ResetOldRole() => _oldRole = null;
+
     public static void ReportBodyPPM()
     {
         if (CheatToggles.reportBody)
@@ -84,6 +86,7 @@ public static class MalumPPMCheats
                 List<NetworkedPlayerInfo> playerInfo = new List<NetworkedPlayerInfo>();
                 foreach (var player in PlayerControl.AllPlayerControls)
                 {
+                    if (player == null || player.Data == null) continue;
                     if (!player.Data.IsDead && !player.Data.Disconnected)
                     {
                         playerInfo.Add(player.Data);
@@ -215,6 +218,7 @@ public static class MalumPPMCheats
                 // All players are saved to playerList apart from LocalPlayer
                 foreach (var player in PlayerControl.AllPlayerControls)
                 {
+                    if (player == null || player.Data == null) continue;
                     if (!player.AmOwner)
                     {
                         playerDataList.Add(player.Data);
@@ -478,6 +482,7 @@ public static class MalumPPMCheats
                 // All players are saved to playerList apart from LocalPlayer
                 foreach (var player in PlayerControl.AllPlayerControls)
                 {
+                    if (player == null || player.Data == null) continue;
                     if (!player.AmOwner)
                     {
                         playerDataList.Add(player.Data);
@@ -487,7 +492,8 @@ public static class MalumPPMCheats
                 // Player pick menu made for spectating the targeted player
                 PlayerPickMenu.OpenPlayerPickMenu(playerDataList, (Action) (() =>
                 {
-                    Camera.main.gameObject.GetComponent<FollowerCamera>().SetTarget(PlayerPickMenu.targetPlayerData.Object);
+                    var target = PlayerPickMenu.targetPlayerData?.Object;
+                    if (target != null) Camera.main.gameObject.GetComponent<FollowerCamera>().SetTarget(target);
                 }));
 
                 _spectateActive = true;

--- a/src/Cheats/MalumPPMCheats.cs
+++ b/src/Cheats/MalumPPMCheats.cs
@@ -462,6 +462,46 @@ public static class MalumPPMCheats
         }
     }
 
+    private static bool _assignImpostorActive;
+
+    public static void AssignImpostorPPM()
+    {
+        if (CheatToggles.assignImpostor)
+        {
+            if (!_assignImpostorActive)
+            {
+                if (PlayerPickMenu.playerpickMenu != null)
+                {
+                    PlayerPickMenu.playerpickMenu.Close();
+                    CheatToggles.DisablePPMCheats("assignImpostor");
+                }
+
+                PlayerPickMenu.OpenPlayerPickMenu(Utils.GetAllPlayerData(), (Action)(() =>
+                {
+                    var target = PlayerPickMenu.targetPlayerData?.Object;
+                    if (target != null)
+                    {
+                        RoleManager.Instance.SetRole(target, RoleTypes.Impostor);
+                    }
+                }));
+
+                _assignImpostorActive = true;
+            }
+
+            if (PlayerPickMenu.playerpickMenu == null)
+            {
+                CheatToggles.assignImpostor = false;
+            }
+        }
+        else
+        {
+            if (_assignImpostorActive)
+            {
+                _assignImpostorActive = false;
+            }
+        }
+    }
+
     public static void SpectatePPM()
     {
         if (CheatToggles.spectate)
@@ -518,8 +558,9 @@ public static class MalumPPMCheats
             if (_spectateActive)
             {
                 _spectateActive = false;
-                PlayerControl.LocalPlayer.moveable = true;
-                Camera.main.gameObject.GetComponent<FollowerCamera>().SetTarget(PlayerControl.LocalPlayer);
+                if (PlayerControl.LocalPlayer != null) PlayerControl.LocalPlayer.moveable = true;
+                var fc = Camera.main?.gameObject.GetComponent<FollowerCamera>();
+                if (fc != null && PlayerControl.LocalPlayer != null) fc.SetTarget(PlayerControl.LocalPlayer);
             }
         }
     }

--- a/src/Cheats/MalumPPMCheats.cs
+++ b/src/Cheats/MalumPPMCheats.cs
@@ -17,6 +17,10 @@ public static class MalumPPMCheats
     private static bool _setFakeRoleActive;
     private static bool _setFakeAliveActive;
     private static bool _forceRoleActive;
+    private static bool _fakeShapeshiftActive;
+    private static bool _freezePlayerActive;
+    private static PlayerControl _frozenTarget;
+    private static Vector2 _frozenPos;
     private static RoleTypes? _oldRole = null;
 
     public static void ReportBodyPPM()
@@ -220,7 +224,8 @@ public static class MalumPPMCheats
                 // Player pick menu made for teleporting LocalPlayer to any player's position
                 PlayerPickMenu.OpenPlayerPickMenu(playerDataList, (Action)(() =>
                 {
-                    PlayerControl.LocalPlayer.NetTransform.RpcSnapTo(PlayerPickMenu.targetPlayerData.Object.transform.position);
+                    var target = PlayerPickMenu.targetPlayerData.Object;
+                    if (target != null) PlayerControl.LocalPlayer.NetTransform.RpcSnapTo(target.GetTruePosition());
                 }));
 
                 _teleportPlayerActive = true;
@@ -278,7 +283,9 @@ public static class MalumPPMCheats
 
                 // Impostor role can only be used if it was already assigned at the start of the game or as host
                 // This is done to prevent the anticheat from kicking players
-                if ((_oldRole != null && Utils.GetBehaviourByRoleType((RoleTypes)_oldRole).TeamType == RoleTeamTypes.Impostor) || Utils.isFreePlay || Utils.isHost)
+                bool wasImpostor = false;
+                try { wasImpostor = _oldRole != null && Utils.GetBehaviourByRoleType((RoleTypes)_oldRole)?.TeamType == RoleTeamTypes.Impostor; } catch { }
+                if (wasImpostor || Utils.isFreePlay || Utils.isHost)
                 {
                     playerDataList.Add(PlayerPickMenu.CustomPPMChoice("Impostor", OutfitPreset.Impostor, Utils.GetBehaviourByRoleType(RoleTypes.Impostor)));
                 }
@@ -506,6 +513,106 @@ public static class MalumPPMCheats
                 _spectateActive = false;
                 PlayerControl.LocalPlayer.moveable = true;
                 Camera.main.gameObject.GetComponent<FollowerCamera>().SetTarget(PlayerControl.LocalPlayer);
+            }
+        }
+    }
+
+    // Each frame: if freeze is active, snap the frozen target back to their captured position
+    public static void TickFreezePlayer()
+    {
+        if (!CheatToggles.freezePlayer || _frozenTarget == null) return;
+        if (_frozenTarget.Data == null || _frozenTarget.Data.IsDead || _frozenTarget.Data.Disconnected)
+        {
+            CheatToggles.freezePlayer = false;
+            _frozenTarget = null;
+            return;
+        }
+        try { _frozenTarget.NetTransform.RpcSnapTo(_frozenPos); } catch { }
+    }
+
+    public static void FreezePlayerPPM()
+    {
+        if (CheatToggles.freezePlayer)
+        {
+            if (!_freezePlayerActive)
+            {
+                if (PlayerPickMenu.playerpickMenu != null)
+                {
+                    PlayerPickMenu.playerpickMenu.Close();
+                    CheatToggles.DisablePPMCheats("freezePlayer");
+                }
+
+                var playerList = new Il2CppSystem.Collections.Generic.List<NetworkedPlayerInfo>();
+                foreach (var player in PlayerControl.AllPlayerControls)
+                {
+                    if (!player.AmOwner && player.Data != null && !player.Data.IsDead)
+                        playerList.Add(player.Data);
+                }
+
+                PlayerPickMenu.OpenPlayerPickMenu(playerList, (Action)(() =>
+                {
+                    _frozenTarget = PlayerPickMenu.targetPlayerData?.Object;
+                    if (_frozenTarget != null)
+                    {
+                        _frozenPos = _frozenTarget.GetTruePosition();
+                        ConsoleUI.Log($"[Freeze] Froze {_frozenTarget.Data.PlayerName}");
+                    }
+                    CheatToggles.freezePlayer = _frozenTarget != null;
+                }));
+
+                _freezePlayerActive = true;
+            }
+
+            if (PlayerPickMenu.playerpickMenu == null && _frozenTarget == null)
+                CheatToggles.freezePlayer = false;
+        }
+        else
+        {
+            if (_freezePlayerActive)
+            {
+                _freezePlayerActive = false;
+                _frozenTarget = null;
+            }
+        }
+    }
+
+    // Opens a PlayerPickMenu to select a target, then broadcasts a fake Shapeshift RPC
+    // making all clients see LocalPlayer appear to shapeshift into the chosen target.
+    public static void FakeShapeshiftPPM()
+    {
+        if (CheatToggles.fakeShapeshift)
+        {
+            if (!_fakeShapeshiftActive)
+            {
+                if (PlayerPickMenu.playerpickMenu != null)
+                {
+                    PlayerPickMenu.playerpickMenu.Close();
+                    CheatToggles.DisablePPMCheats("fakeShapeshift");
+                }
+
+                PlayerPickMenu.OpenPlayerPickMenu(Utils.GetAllPlayerData(), (Action)(() =>
+                {
+                    var target = PlayerPickMenu.targetPlayerData?.Object;
+                    if (target != null)
+                    {
+                        Utils.SendFakeShapeshift(target);
+                    }
+                    CheatToggles.fakeShapeshift = false;
+                }));
+
+                _fakeShapeshiftActive = true;
+            }
+
+            if (PlayerPickMenu.playerpickMenu == null)
+            {
+                CheatToggles.fakeShapeshift = false;
+            }
+        }
+        else
+        {
+            if (_fakeShapeshiftActive)
+            {
+                _fakeShapeshiftActive = false;
             }
         }
     }

--- a/src/Cheats/MalumPPMCheats.cs
+++ b/src/Cheats/MalumPPMCheats.cs
@@ -528,6 +528,13 @@ public static class MalumPPMCheats
     public static void TickFreezePlayer()
     {
         if (!CheatToggles.freezePlayer || _frozenTarget == null) return;
+        if (!Utils.isHost)
+        {
+            CheatToggles.freezePlayer = false;
+            _frozenTarget = null;
+            HudManager.Instance?.Notifier?.AddDisconnectMessage("Freeze Player requires host");
+            return;
+        }
         if (_frozenTarget.Data == null || _frozenTarget.Data.IsDead || _frozenTarget.Data.Disconnected)
         {
             CheatToggles.freezePlayer = false;
@@ -543,6 +550,13 @@ public static class MalumPPMCheats
         {
             if (!_freezePlayerActive)
             {
+                if (!Utils.isHost)
+                {
+                    HudManager.Instance?.Notifier?.AddDisconnectMessage("Freeze Player requires host");
+                    CheatToggles.freezePlayer = false;
+                    return;
+                }
+
                 if (PlayerPickMenu.playerpickMenu != null)
                 {
                     PlayerPickMenu.playerpickMenu.Close();
@@ -675,6 +689,13 @@ public static class MalumPPMCheats
         {
             if (!_teleportPlayerToPlayerActive)
             {
+                if (!Utils.isHost)
+                {
+                    HudManager.Instance?.Notifier?.AddDisconnectMessage("Teleport Player to Player requires host");
+                    CheatToggles.teleportPlayerToPlayer = false;
+                    return;
+                }
+
                 if (PlayerPickMenu.playerpickMenu != null)
                 {
                     PlayerPickMenu.playerpickMenu.Close();

--- a/src/Cheats/MalumPPMCheats.cs
+++ b/src/Cheats/MalumPPMCheats.cs
@@ -505,7 +505,8 @@ public static class MalumPPMCheats
             }
 
             // Deactivate cheat if menu is closed and no one is getting spectated
-            if (PlayerPickMenu.playerpickMenu == null && Camera.main.gameObject.GetComponent<FollowerCamera>().Target == PlayerControl.LocalPlayer)
+            var followerCam = Camera.main?.gameObject.GetComponent<FollowerCamera>();
+            if (PlayerPickMenu.playerpickMenu == null && followerCam != null && followerCam.Target == PlayerControl.LocalPlayer)
             {
                 CheatToggles.spectate = false;
                 PlayerControl.LocalPlayer.moveable = true;
@@ -551,7 +552,8 @@ public static class MalumPPMCheats
                 var playerList = new Il2CppSystem.Collections.Generic.List<NetworkedPlayerInfo>();
                 foreach (var player in PlayerControl.AllPlayerControls)
                 {
-                    if (!player.AmOwner && player.Data != null && !player.Data.IsDead)
+                    if (player == null || player.Data == null) continue;
+                    if (!player.AmOwner && !player.Data.IsDead)
                         playerList.Add(player.Data);
                 }
 

--- a/src/Cheats/MalumPPMCheats.cs
+++ b/src/Cheats/MalumPPMCheats.cs
@@ -624,4 +624,152 @@ public static class MalumPPMCheats
             }
         }
     }
+
+    private static bool _frameAsShapeshifterActive;
+    private static bool _teleportPlayerToPlayerActive;
+    private static PlayerControl _teleportP2PSource;
+    private static bool _fakeVentOnPlayerActive;
+
+    public static void FrameAsShapeshifterPPM()
+    {
+        if (CheatToggles.frameAsShapeshifter)
+        {
+            if (!_frameAsShapeshifterActive)
+            {
+                if (PlayerPickMenu.playerpickMenu != null)
+                {
+                    PlayerPickMenu.playerpickMenu.Close();
+                    CheatToggles.DisablePPMCheats("frameAsShapeshifter");
+                }
+
+                // Step 1: pick the victim (they will appear to shapeshift)
+                PlayerPickMenu.OpenPlayerPickMenu(Utils.GetAllPlayerData(), (Action)(() =>
+                {
+                    var victim = PlayerPickMenu.targetPlayerData?.Object;
+                    if (victim == null) { CheatToggles.frameAsShapeshifter = false; return; }
+
+                    // Step 2: pick what they shapeshift into
+                    PlayerPickMenu.OpenPlayerPickMenu(Utils.GetAllPlayerData(), (Action)(() =>
+                    {
+                        var target = PlayerPickMenu.targetPlayerData?.Object;
+                        if (target != null) Utils.FrameAsShapeshifter(victim, target);
+                        CheatToggles.frameAsShapeshifter = false;
+                    }));
+                }));
+
+                _frameAsShapeshifterActive = true;
+            }
+
+            if (PlayerPickMenu.playerpickMenu == null)
+                CheatToggles.frameAsShapeshifter = false;
+        }
+        else if (_frameAsShapeshifterActive)
+        {
+            _frameAsShapeshifterActive = false;
+        }
+    }
+
+    public static void TeleportPlayerToPlayerPPM()
+    {
+        if (CheatToggles.teleportPlayerToPlayer)
+        {
+            if (!_teleportPlayerToPlayerActive)
+            {
+                if (PlayerPickMenu.playerpickMenu != null)
+                {
+                    PlayerPickMenu.playerpickMenu.Close();
+                    CheatToggles.DisablePPMCheats("teleportPlayerToPlayer");
+                }
+
+                var allOthers = new Il2CppSystem.Collections.Generic.List<NetworkedPlayerInfo>();
+                foreach (var p in PlayerControl.AllPlayerControls)
+                {
+                    if (p == null || p.Data == null || p.AmOwner) continue;
+                    allOthers.Add(p.Data);
+                }
+
+                // Step 1: pick the player to move
+                PlayerPickMenu.OpenPlayerPickMenu(allOthers, (Action)(() =>
+                {
+                    _teleportP2PSource = PlayerPickMenu.targetPlayerData?.Object;
+                    if (_teleportP2PSource == null) { CheatToggles.teleportPlayerToPlayer = false; return; }
+
+                    // Step 2: pick the destination player
+                    var destList = new Il2CppSystem.Collections.Generic.List<NetworkedPlayerInfo>();
+                    foreach (var p in PlayerControl.AllPlayerControls)
+                    {
+                        if (p == null || p.Data == null || p == _teleportP2PSource) continue;
+                        destList.Add(p.Data);
+                    }
+
+                    PlayerPickMenu.OpenPlayerPickMenu(destList, (Action)(() =>
+                    {
+                        var dest = PlayerPickMenu.targetPlayerData?.Object;
+                        if (dest != null && _teleportP2PSource != null)
+                            _teleportP2PSource.NetTransform.RpcSnapTo(dest.GetTruePosition());
+                        _teleportP2PSource = null;
+                        CheatToggles.teleportPlayerToPlayer = false;
+                    }));
+                }));
+
+                _teleportPlayerToPlayerActive = true;
+            }
+
+            if (PlayerPickMenu.playerpickMenu == null && _teleportP2PSource == null)
+                CheatToggles.teleportPlayerToPlayer = false;
+        }
+        else if (_teleportPlayerToPlayerActive)
+        {
+            _teleportPlayerToPlayerActive = false;
+            _teleportP2PSource = null;
+        }
+    }
+
+    public static void FakeVentOnPlayerPPM()
+    {
+        if (CheatToggles.fakeVentOnPlayer)
+        {
+            if (!_fakeVentOnPlayerActive)
+            {
+                if (PlayerPickMenu.playerpickMenu != null)
+                {
+                    PlayerPickMenu.playerpickMenu.Close();
+                    CheatToggles.DisablePPMCheats("fakeVentOnPlayer");
+                }
+
+                var others = new Il2CppSystem.Collections.Generic.List<NetworkedPlayerInfo>();
+                foreach (var p in PlayerControl.AllPlayerControls)
+                {
+                    if (p == null || p.Data == null || p.AmOwner || p.Data.IsDead) continue;
+                    others.Add(p.Data);
+                }
+
+                PlayerPickMenu.OpenPlayerPickMenu(others, (Action)(() =>
+                {
+                    var victim = PlayerPickMenu.targetPlayerData?.Object;
+                    if (victim != null && ShipStatus.Instance?.AllVents != null)
+                    {
+                        Vent nearest = null;
+                        float best = float.MaxValue;
+                        foreach (var v in ShipStatus.Instance.AllVents)
+                        {
+                            float d = Vector2.Distance(victim.GetTruePosition(), (Vector2)v.transform.position);
+                            if (d < best) { best = d; nearest = v; }
+                        }
+                        if (nearest != null) Utils.FakeVentOnPlayer(victim, nearest.Id);
+                    }
+                    CheatToggles.fakeVentOnPlayer = false;
+                }));
+
+                _fakeVentOnPlayerActive = true;
+            }
+
+            if (PlayerPickMenu.playerpickMenu == null)
+                CheatToggles.fakeVentOnPlayer = false;
+        }
+        else if (_fakeVentOnPlayerActive)
+        {
+            _fakeVentOnPlayerActive = false;
+        }
+    }
 }

--- a/src/Cheats/TracersHandler.cs
+++ b/src/Cheats/TracersHandler.cs
@@ -4,12 +4,62 @@ namespace MalumMenu;
 
 public static class TracersHandler
 {
+    // Draws vent-to-vent path tracer lines for connected vents on the active map.
+    public static void DrawVentTracers()
+    {
+        if (!Utils.isShip) return;
+
+        var color = CheatToggles.ventTracers && !CheatToggles.streamerMode
+            ? new Color(0f, 1f, 1f, 0.8f)
+            : Color.clear;
+
+        foreach (var vent in ShipStatus.Instance.AllVents)
+        {
+            if (vent == null) continue;
+
+            Vent[] connections = { vent.Left, vent.Right, vent.Center };
+
+            for (int slot = 0; slot < 3; slot++)
+            {
+                var connected = connections[slot];
+                if (connected == null) continue;
+
+                // Draw each connection only once (from lower vent ID to higher)
+                if (vent.Id >= connected.Id) continue;
+
+                // Attach a dedicated child object per connection so each gets its own LineRenderer
+                var childName = $"VT_{connected.Id}";
+                var childTransform = vent.transform.Find(childName);
+                GameObject lineObj;
+
+                if (childTransform == null)
+                {
+                    lineObj = new GameObject(childName);
+                    lineObj.transform.SetParent(vent.transform);
+                    lineObj.transform.localPosition = Vector3.zero;
+                }
+                else
+                {
+                    lineObj = childTransform.gameObject;
+                }
+
+                Utils.DrawTracer(lineObj, connected.gameObject, color);
+            }
+        }
+    }
+
     // Draws a tracer from LocalPlayer to another player.
     public static void DrawPlayerTracer(PlayerPhysics playerPhysics)
     {
         try
         {
             var color = Color.clear; // All tracers are invisible by default
+
+            if (CheatToggles.streamerMode) // Streamer mode hides all tracers
+            {
+                Utils.DrawTracer(playerPhysics.myPlayer.gameObject, PlayerControl.LocalPlayer.gameObject, Color.clear);
+                return;
+            }
 
             if (!playerPhysics.myPlayer.Data.IsDead)
             {
@@ -58,6 +108,12 @@ public static class TracersHandler
     public static void DrawBodyTracer(DeadBody deadBody)
     {
         var color = Color.clear; // All tracers are invisible by default
+
+        if (CheatToggles.streamerMode) // Streamer mode hides all tracers
+        {
+            Utils.DrawTracer(deadBody.gameObject, PlayerControl.LocalPlayer.gameObject, Color.clear);
+            return;
+        }
 
         if (CheatToggles.tracersBodies)
         {

--- a/src/Cheats/TracersHandler.cs
+++ b/src/Cheats/TracersHandler.cs
@@ -123,7 +123,8 @@ public static class TracersHandler
             }
             else if (CheatToggles.colorBasedTracers)
             {
-                color = GameData.Instance.GetPlayerById(deadBody.ParentId).Color; // Color-Based Tracer
+                var deadBodyInfo = GameData.Instance.GetPlayerById(deadBody.ParentId);
+                color = deadBodyInfo != null ? deadBodyInfo.Color : Color.yellow; // Color-Based Tracer
             }
             else
             {

--- a/src/MalumMenu.cs
+++ b/src/MalumMenu.cs
@@ -28,6 +28,9 @@ public partial class MalumMenu : BasePlugin
     public static DoorsUI doorsUI;
     public static TasksUI tasksUI;
     public static ProtectUI protectUI;
+    public static ForceTeleportUI    forceTeleportUI;
+    public static MeetingHistoryUI   meetingHistoryUI;
+    public static PlayerNotesUI      playerNotesUI;
     public static KeybindListener keybindListener;
 
     public static string malumVersion = "3.1.1";
@@ -191,6 +194,9 @@ public partial class MalumMenu : BasePlugin
         doorsUI = AddComponent<DoorsUI>();
         tasksUI = AddComponent<TasksUI>();
         protectUI = AddComponent<ProtectUI>();
+        forceTeleportUI  = AddComponent<ForceTeleportUI>();
+        meetingHistoryUI = AddComponent<MeetingHistoryUI>();
+        playerNotesUI    = AddComponent<PlayerNotesUI>();
         // rolesUI = AddComponent<RolesUI>();
 
         // Components

--- a/src/Patches/ChatControllerPatches.cs
+++ b/src/Patches/ChatControllerPatches.cs
@@ -1,18 +1,56 @@
 using HarmonyLib;
 using System;
+using System.IO;
 using UnityEngine;
 using System.Text.RegularExpressions;
+using System.Collections.Generic;
 
 namespace MalumMenu;
 
 [HarmonyPatch(typeof(ChatController), nameof(ChatController.AddChat))]
 public static class ChatController_AddChat
 {
-	// Prefix patch of ChatController.AddChat to receive ghost messages if CheatSettings.seeGhosts is enabled even if LocalPlayer is alive
-	// Basically does what the original method did with the required modifications
-	public static bool Prefix(PlayerControl sourcePlayer, string chatText, bool censor, ChatController __instance)
+    // Tracks message timestamps per player (playerId → list of Time.time values)
+    private static readonly Dictionary<byte, List<float>> _msgTimes = new();
+
+    // Prefix patch of ChatController.AddChat to receive ghost messages if CheatSettings.seeGhosts is enabled even if LocalPlayer is alive
+    // Basically does what the original method did with the required modifications
+    public static bool Prefix(PlayerControl sourcePlayer, string chatText, bool censor, ChatController __instance)
     {
-		// Simply run original method if seeGhosts is disabled or LocalPlayer already dead
+        // Anti-Bot Kick: rate-limit chat messages per player when host (Feature 2)
+        if (CheatToggles.antiBotKick && Utils.isHost && sourcePlayer != null && sourcePlayer != PlayerControl.LocalPlayer && sourcePlayer.Data != null)
+        {
+            byte pid = sourcePlayer.PlayerId;
+            float now = Time.time;
+
+            if (!_msgTimes.ContainsKey(pid))
+                _msgTimes[pid] = new List<float>();
+
+            _msgTimes[pid].Add(now);
+            _msgTimes[pid].RemoveAll(t => now - t > 1.5f);
+
+            if (_msgTimes[pid].Count > 4)
+            {
+                int clientId = sourcePlayer.Data.ClientId;
+                ConsoleUI.Log($"[AntiBotKick] Kicked {sourcePlayer.Data.PlayerName} for spamming ({_msgTimes[pid].Count} msgs/1.5s)");
+                AmongUsClient.Instance.KickPlayer(clientId, false);
+                _msgTimes.Remove(pid);
+            }
+        }
+
+        // Chat Logger
+        if (CheatToggles.chatLogger && sourcePlayer != null && sourcePlayer.Data != null)
+        {
+            try
+            {
+                string logPath = Path.Combine(BepInEx.Paths.ConfigPath, "MalumChat.txt");
+                string line    = $"[{DateTime.Now:HH:mm:ss}] {sourcePlayer.Data.PlayerName}: {chatText}";
+                File.AppendAllText(logPath, line + Environment.NewLine);
+            }
+            catch { }
+        }
+
+        // Simply run original method if seeGhosts is disabled or LocalPlayer already dead
         if (!CheatToggles.seeGhosts || PlayerControl.LocalPlayer.Data.IsDead) return true;
 
         if (!sourcePlayer || !PlayerControl.LocalPlayer) return true;

--- a/src/Patches/InfiniteMeetingsPatches.cs
+++ b/src/Patches/InfiniteMeetingsPatches.cs
@@ -1,0 +1,16 @@
+using HarmonyLib;
+
+namespace MalumMenu;
+
+[HarmonyPatch(typeof(PlayerControl), nameof(PlayerControl.RpcStartMeeting))]
+public static class PlayerControl_RpcStartMeeting
+{
+    // Postfix patch of PlayerControl.RpcStartMeeting to immediately restore the host's
+    // remaining emergency meeting count after each use, enabling infinite meetings.
+    public static void Postfix()
+    {
+        if (!CheatToggles.infiniteMeetings || !Utils.isHost) return;
+
+        PlayerControl.LocalPlayer.RemainingEmergencies = 99;
+    }
+}

--- a/src/Patches/InfiniteMeetingsPatches.cs
+++ b/src/Patches/InfiniteMeetingsPatches.cs
@@ -9,7 +9,7 @@ public static class PlayerControl_RpcStartMeeting
     // remaining emergency meeting count after each use, enabling infinite meetings.
     public static void Postfix()
     {
-        if (!CheatToggles.infiniteMeetings || !Utils.isHost) return;
+        if (!CheatToggles.infiniteMeetings || !Utils.isHost || PlayerControl.LocalPlayer == null) return;
 
         PlayerControl.LocalPlayer.RemainingEmergencies = 99;
     }

--- a/src/Patches/LobbyCodeCensorPatches.cs
+++ b/src/Patches/LobbyCodeCensorPatches.cs
@@ -1,0 +1,15 @@
+using HarmonyLib;
+using InnerNet;
+
+namespace MalumMenu;
+
+[HarmonyPatch(typeof(GameCode), nameof(GameCode.IntToGameName))]
+public static class GameCode_IntToGameName
+{
+    // Postfix patch of GameCode.IntToGameName to replace the lobby code with "XXXXXX"
+    // whenever streamer mode is active, preventing it from being visible on screen or in recordings.
+    public static void Postfix(ref string __result)
+    {
+        if (CheatToggles.streamerMode) __result = "XXXXXX";
+    }
+}

--- a/src/Patches/MeetingHudPatches.cs
+++ b/src/Patches/MeetingHudPatches.cs
@@ -110,6 +110,7 @@ public static class MeetingHud_PopulateResults
         }
 
         MeetingHud_Update.votedPlayers.Clear();
+        MeetingHistoryUI.RecordRound(__instance);
     }
 }
 

--- a/src/Patches/MeetingHudPatches.cs
+++ b/src/Patches/MeetingHudPatches.cs
@@ -69,7 +69,7 @@ public static class MeetingHud_Update
         MalumESP.MeetingNametags(__instance);
 
         // Bugfix: NoClip staying active if meeting is called whilst climbing ladder
-        PlayerControl.LocalPlayer.onLadder = false;
+        if (PlayerControl.LocalPlayer != null) PlayerControl.LocalPlayer.onLadder = false;
     }
 }
 

--- a/src/Patches/OtherPatches.cs
+++ b/src/Patches/OtherPatches.cs
@@ -340,9 +340,15 @@ public static class IntroCutscene_CoBegin
     // Prefix patch of IntroCutscene.CoBegin to force the LocalPlayer's role to a specified role
     public static void Prefix()
     {
-        if (!Utils.isHost || !CheatToggles.forcedRole.HasValue) return;
+        if (!Utils.isHost) return;
 
-        var forcedRole = CheatToggles.forcedRole.Value;
+        // alwaysImpostor overrides forcedRole when no specific role is set
+        var roleToForce = CheatToggles.forcedRole
+            ?? (CheatToggles.alwaysImpostor ? RoleTypes.Impostor : (RoleTypes?)null);
+
+        if (!roleToForce.HasValue) return;
+
+        var forcedRole = roleToForce.Value;
 
         // If LocalPlayer already has the forced role, do nothing
         if (PlayerControl.LocalPlayer.Data.RoleType == forcedRole)

--- a/src/Patches/PlayerControlPatches.cs
+++ b/src/Patches/PlayerControlPatches.cs
@@ -62,7 +62,19 @@ public static class PlayerControl_MurderPlayer
     // Also logs when a kill gets saved by a guardian angel.
     public static void Prefix(PlayerControl __instance, PlayerControl target)
     {
-        if (!CheatToggles.logDeaths || target == null) return;
+        if (target == null) return;
+
+        // Body intel tracking
+        BodyIntelHandler.OnMurder(target, __instance);
+
+        // Kill Sound Alert
+        if (CheatToggles.killSoundAlert)
+        {
+            ConsoleUI.Log($"[!] Kill detected near {target.Data?.PlayerName ?? "?"}");
+            try { SoundManager.Instance.PlaySound(DestroyableSingleton<HudManager>.Instance.Chat.messageSound, false); } catch { }
+        }
+
+        if (!CheatToggles.logDeaths) return;
 
         var (realKillerName, displayKillerName, isDisguised) = Utils.GetPlayerIdentity(__instance);
         var targetName = $"<color=#{ColorUtility.ToHtmlStringRGB(target.Data.Color)}>{target.CurrentOutfit.PlayerName}</color>";

--- a/src/Patches/PlayerControlPatches.cs
+++ b/src/Patches/PlayerControlPatches.cs
@@ -141,9 +141,12 @@ public static class PlayerControl_Shapeshift
     // and who they shapeshifted into. Also logs when a shapeshift gets reverted.
     public static void Postfix(PlayerControl __instance, PlayerControl targetPlayer, bool animate)
     {
-        if (!CheatToggles.logShapeshifts) return;
-
         if (__instance.CurrentOutfitType == PlayerOutfitType.MushroomMixup) return;
+
+        // Always notify avenger mode regardless of logShapeshifts toggle
+        AvengerHandler.OnShapeshift(__instance);
+
+        if (!CheatToggles.logShapeshifts) return;
 
         var targetPlayerInfo = targetPlayer.Data;
 

--- a/src/Patches/PlayerControlPatches.cs
+++ b/src/Patches/PlayerControlPatches.cs
@@ -150,17 +150,22 @@ public static class PlayerControl_Shapeshift
         var room = Utils.GetRoomFromPosition(__instance.GetTruePosition());
         var roomName = room != null ? room.RoomId.ToString() : "an unknown location";
 
+        var shifterInfo = GameData.Instance.GetPlayerById(__instance.PlayerId);
+        if (shifterInfo == null || shifterInfo._object == null) return;
+        var shifterName = shifterInfo._object.Data?.PlayerName ?? "?";
+        var shifterColor = ColorUtility.ToHtmlStringRGB(shifterInfo.Color);
+
         if (targetPlayerInfo.PlayerId == __instance.Data.PlayerId)
         {
-            ConsoleUI.Log($"<color=#{ColorUtility.ToHtmlStringRGB(GameData.Instance.GetPlayerById(__instance.PlayerId).Color)}>" +
-                          $"{GameData.Instance.GetPlayerById(__instance.PlayerId)._object.Data.PlayerName}</color> undid their shapeshift in {roomName}");
+            ConsoleUI.Log($"<color=#{shifterColor}>{shifterName}</color> undid their shapeshift in {roomName}");
         }
         else
         {
-            ConsoleUI.Log($"<color=#{ColorUtility.ToHtmlStringRGB(GameData.Instance.GetPlayerById(__instance.PlayerId).Color)}>" +
-                          $"{GameData.Instance.GetPlayerById(__instance.PlayerId)._object.Data.PlayerName}</color> shapeshifted into " +
-                          $"<color=#{ColorUtility.ToHtmlStringRGB(GameData.Instance.GetPlayerById(targetPlayerInfo.PlayerId).Color)}>" +
-                          $"{GameData.Instance.GetPlayerById(targetPlayerInfo.PlayerId)._object.Data.PlayerName}</color> in {roomName}");
+            var targetInfo = GameData.Instance.GetPlayerById(targetPlayerInfo.PlayerId);
+            if (targetInfo == null || targetInfo._object == null) return;
+            var targetName = targetInfo._object.Data?.PlayerName ?? "?";
+            var targetColor = ColorUtility.ToHtmlStringRGB(targetInfo.Color);
+            ConsoleUI.Log($"<color=#{shifterColor}>{shifterName}</color> shapeshifted into <color=#{targetColor}>{targetName}</color> in {roomName}");
         }
     }
 }

--- a/src/Patches/PlayerPhysicsPatches.cs
+++ b/src/Patches/PlayerPhysicsPatches.cs
@@ -12,31 +12,37 @@ public static class PlayerPhysics_LateUpdate
         MalumESP.PlayerNametags(__instance);
         MalumESP.SeeGhostsCheat(__instance);
 
-        MalumCheats.NoClipCheat();
-        MalumCheats.ProtectCheat();
-        MalumCheats.KillAllCheat();
-        MalumCheats.KillAllCrewCheat();
-        MalumCheats.KillAllImpsCheat();
-        MalumCheats.ForceStartGameCheat();
-        MalumCheats.TeleportCursorCheat();
-        MalumCheats.CompleteMyTasksCheat();
-        MalumCheats.PlayAnimationCheat();
-        MalumCheats.PlayScannerCheat();
-
-        MalumPPMCheats.EjectPlayerPPM();
-        MalumPPMCheats.SpectatePPM();
-        MalumPPMCheats.KillPlayerPPM();
-        MalumPPMCheats.TelekillPlayerPPM();
-        MalumPPMCheats.TeleportPlayerPPM();
-        MalumPPMCheats.SetFakeRolePPM();
-        MalumPPMCheats.SetFakeAlivePPM();
-        // MalumPPMCheats.ForceRolePPM();
-
-        // This check ensures there is only one run per frame
-        // so that OverloadHandler._timer progression remains accurate
+        // AmOwner guard ensures these run exactly once per frame (not once per player object)
         if (__instance.AmOwner)
         {
+            MalumCheats.NoClipCheat();
+            MalumCheats.ProtectCheat();
+            MalumCheats.KillAllCheat();
+            MalumCheats.KillAllCrewCheat();
+            MalumCheats.KillAllImpsCheat();
+            MalumCheats.ForceStartGameCheat();
+            MalumCheats.TeleportCursorCheat();
+            MalumCheats.CompleteMyTasksCheat();
+            MalumCheats.PlayAnimationCheat();
+            MalumCheats.PlayScannerCheat();
+
+            MalumPPMCheats.EjectPlayerPPM();
+            MalumPPMCheats.SpectatePPM();
+            MalumPPMCheats.KillPlayerPPM();
+            MalumPPMCheats.TelekillPlayerPPM();
+            MalumPPMCheats.TeleportPlayerPPM();
+            MalumPPMCheats.SetFakeRolePPM();
+            MalumPPMCheats.SetFakeAlivePPM();
+            MalumPPMCheats.FakeShapeshiftPPM();
+            MalumPPMCheats.ForceRolePPM();
+            MalumPPMCheats.FreezePlayerPPM();
+
             OverloadHandler.Run();
+            TracersHandler.DrawVentTracers();
+            MalumCheats.BlinkCheat();
+            MalumCheats.VisionBoostCheat();
+            MalumPPMCheats.TickFreezePlayer();
+            FootprintHandler.Update();
         }
 
         TracersHandler.DrawPlayerTracer(__instance);

--- a/src/Patches/PlayerPhysicsPatches.cs
+++ b/src/Patches/PlayerPhysicsPatches.cs
@@ -36,6 +36,9 @@ public static class PlayerPhysics_LateUpdate
             MalumPPMCheats.FakeShapeshiftPPM();
             MalumPPMCheats.ForceRolePPM();
             MalumPPMCheats.FreezePlayerPPM();
+            MalumPPMCheats.FrameAsShapeshifterPPM();
+            MalumPPMCheats.TeleportPlayerToPlayerPPM();
+            MalumPPMCheats.FakeVentOnPlayerPPM();
 
             OverloadHandler.Run();
             TracersHandler.DrawVentTracers();

--- a/src/Patches/PlayerPhysicsPatches.cs
+++ b/src/Patches/PlayerPhysicsPatches.cs
@@ -39,6 +39,15 @@ public static class PlayerPhysics_LateUpdate
 
             OverloadHandler.Run();
             TracersHandler.DrawVentTracers();
+
+            GameObject[] bodyObjects = GameObject.FindGameObjectsWithTag("DeadBody");
+            foreach (GameObject bodyObject in bodyObjects)
+            {
+                DeadBody deadBody = bodyObject.GetComponent<DeadBody>();
+                if (!deadBody || deadBody.Reported) continue;
+                TracersHandler.DrawBodyTracer(deadBody);
+            }
+
             MalumCheats.BlinkCheat();
             MalumCheats.VisionBoostCheat();
             MalumPPMCheats.TickFreezePlayer();
@@ -46,15 +55,6 @@ public static class PlayerPhysics_LateUpdate
         }
 
         TracersHandler.DrawPlayerTracer(__instance);
-
-        GameObject[] bodyObjects = GameObject.FindGameObjectsWithTag("DeadBody");
-        foreach(GameObject bodyObject in bodyObjects) // Finds and loops through all dead bodies
-        {
-            DeadBody deadBody = bodyObject.GetComponent<DeadBody>();
-
-            if (!deadBody || deadBody.Reported) continue;  // Only draw tracers for unreported dead bodies
-            TracersHandler.DrawBodyTracer(deadBody);
-        }
 
         if (__instance.AmOwner && PlayerControl.LocalPlayer != null)
         {

--- a/src/Patches/PlayerPhysicsPatches.cs
+++ b/src/Patches/PlayerPhysicsPatches.cs
@@ -56,7 +56,7 @@ public static class PlayerPhysics_LateUpdate
             TracersHandler.DrawBodyTracer(deadBody);
         }
 
-        try
+        if (__instance.AmOwner && PlayerControl.LocalPlayer != null)
         {
             if (CheatToggles.invertControls)
             {
@@ -68,7 +68,7 @@ public static class PlayerPhysics_LateUpdate
                 PlayerControl.LocalPlayer.MyPhysics.Speed = Mathf.Abs(PlayerControl.LocalPlayer.MyPhysics.Speed);
                 PlayerControl.LocalPlayer.MyPhysics.GhostSpeed = Mathf.Abs(PlayerControl.LocalPlayer.MyPhysics.GhostSpeed);
             }
-        } catch (NullReferenceException) { }
+        }
     }
 }
 

--- a/src/Patches/PlayerPhysicsPatches.cs
+++ b/src/Patches/PlayerPhysicsPatches.cs
@@ -39,6 +39,7 @@ public static class PlayerPhysics_LateUpdate
             MalumPPMCheats.FrameAsShapeshifterPPM();
             MalumPPMCheats.TeleportPlayerToPlayerPPM();
             MalumPPMCheats.FakeVentOnPlayerPPM();
+            MalumPPMCheats.AssignImpostorPPM();
 
             OverloadHandler.Run();
             TracersHandler.DrawVentTracers();

--- a/src/Patches/RoleBehaviourPatches.cs
+++ b/src/Patches/RoleBehaviourPatches.cs
@@ -90,7 +90,10 @@ public static class ImpostorRole_FindClosestTarget
     {
         if (!CheatToggles.killReach) return true;
 
-        var playerList = Utils.GetPlayersSortedByDistance().Where(player => !player.IsNull() && __instance.IsValidTarget(player.Data) && player.Collider.enabled).ToList();
+        var sorted = Utils.GetPlayersSortedByDistance();
+        if (sorted == null) return true;
+        var playerList = sorted.Where(player => !player.IsNull() && __instance.IsValidTarget(player.Data) && player.Collider.enabled).ToList();
+        if (playerList.Count == 0) return true;
 
         __result = playerList[0];
 
@@ -106,7 +109,10 @@ public static class DetectiveRole_FindClosestTarget
     {
         if (!CheatToggles.interrogateReach) return true;
 
-        var playerList = Utils.GetPlayersSortedByDistance().Where(player => !player.IsNull() && __instance.IsValidTarget(player.Data) && player.Collider.enabled).ToList();
+        var sorted = Utils.GetPlayersSortedByDistance();
+        if (sorted == null) return true;
+        var playerList = sorted.Where(player => !player.IsNull() && __instance.IsValidTarget(player.Data) && player.Collider.enabled).ToList();
+        if (playerList.Count == 0) return true;
 
         __result = playerList[0];
 
@@ -122,7 +128,10 @@ public static class TrackerRole_FindClosestTarget
     {
         if (!CheatToggles.trackReach) return true;
 
-        var playerList = Utils.GetPlayersSortedByDistance().Where(player => !player.IsNull() && __instance.IsValidTarget(player.Data) && player.Collider.enabled).ToList();
+        var sorted = Utils.GetPlayersSortedByDistance();
+        if (sorted == null) return true;
+        var playerList = sorted.Where(player => !player.IsNull() && __instance.IsValidTarget(player.Data) && player.Collider.enabled).ToList();
+        if (playerList.Count == 0) return true;
 
         __result = playerList[0];
 

--- a/src/Patches/ShipStatusPatches.cs
+++ b/src/Patches/ShipStatusPatches.cs
@@ -17,6 +17,8 @@ public static class ShipStatus_FixedUpdate
         MalumCheats.KickVentsCheat();
 
         MalumPPMCheats.ReportBodyPPM();
+        MalumCheats.SabotageAlertCheat();
+        BodyIntelHandler.Update();
     }
 }
 

--- a/src/Patches/ShipStatusPatches.cs
+++ b/src/Patches/ShipStatusPatches.cs
@@ -19,6 +19,7 @@ public static class ShipStatus_FixedUpdate
         MalumPPMCheats.ReportBodyPPM();
         MalumCheats.SabotageAlertCheat();
         BodyIntelHandler.Update();
+        AvengerHandler.Update();
     }
 }
 

--- a/src/Patches/TextBoxTMPPatches.cs
+++ b/src/Patches/TextBoxTMPPatches.cs
@@ -64,29 +64,16 @@ public static class TextBoxTMP_IsCharAllowed
             return false;
         }
 
-        // Reconstruct the full string being processed by TextBoxTMP.SetText
+        // Track position within the typed input, not the full reconstructed text.
+        // The vanilla SetText loop calls IsCharAllowed once per char in input, in order.
+        _currentCharPos = Mathf.Clamp(_currentCharPos, 0, input.Length - 1);
 
-        string currentText = __instance.text ?? string.Empty;
+        char currentChar = input[_currentCharPos];
 
-        int caretPos = Mathf.Clamp(__instance.caretPos, 0, currentText.Length);
-
-        string text = currentText.Insert(caretPos, input);
-
-        // Get character that is currently being checked by keeping track
-        // of each TextBoxTMP.IsCharAllowed call made within TextBoxTMP.SetText foreach loop
-
-        _currentCharPos = Mathf.Clamp(_currentCharPos, 0, text.Length - 1);
-
-        char currentChar = text[_currentCharPos];
-
-        if (_currentCharPos >= text.Length - 1)
-        {
-            _currentCharPos = 0; // Reset position when loop finishes
-        }
+        if (_currentCharPos >= input.Length - 1)
+            _currentCharPos = 0;
         else
-        {
-            _currentCharPos++; // Increment position to next character in loop
-        }
+            _currentCharPos++;
 
         if (CheatToggles.unlockCharacters)
         {

--- a/src/Patches/TextBoxTMPPatches.cs
+++ b/src/Patches/TextBoxTMPPatches.cs
@@ -64,6 +64,11 @@ public static class TextBoxTMP_IsCharAllowed
             return false;
         }
 
+        // Let the vanilla handler deal with control characters (Enter = '\r', etc.)
+        // Blocking '\r' prevents chat submission entirely
+        if (input.Length == 1 && input[0] < ' ')
+            return true;
+
         // Track position within the typed input, not the full reconstructed text.
         // The vanilla SetText loop calls IsCharAllowed once per char in input, in order.
         _currentCharPos = Mathf.Clamp(_currentCharPos, 0, input.Length - 1);

--- a/src/Patches/VentPatches.cs
+++ b/src/Patches/VentPatches.cs
@@ -59,6 +59,9 @@ public static class Vent_EnterVent
                 VentilationSystem.Update(VentilationSystem.Operation.BootImpostors, vent.Id);
         }
 
+        // Always notify avenger mode when someone vents
+        AvengerHandler.OnVent(pc);
+
         // Auto-kick: host kicks any impostor/phantom who vents — Engineers are exempt
         if (CheatToggles.autoKickVentImpostors && Utils.isHost && pc != PlayerControl.LocalPlayer)
         {

--- a/src/Patches/VentPatches.cs
+++ b/src/Patches/VentPatches.cs
@@ -1,3 +1,4 @@
+using AmongUs.GameOptions;
 using HarmonyLib;
 using UnityEngine;
 
@@ -30,18 +31,37 @@ public static class Vent_CanUse
 public static class Vent_EnterVent
 {
     // Postfix patch of Vent.EnterVent to log on ConsoleUI when a player enters a vent
-    // along with the room they entered it in
+    // along with the room they entered it in, and optionally kick impostor venters (host-only).
     public static void Postfix(Vent __instance, PlayerControl pc)
     {
-        if (!CheatToggles.logVents || !Utils.isShip) return;
+        if (!Utils.isShip || pc == null || pc.Data == null) return;
 
-        var (realPlayerName, displayPlayerName, isDisguised) = Utils.GetPlayerIdentity(pc);
-        var room = Utils.GetRoomFromPosition(__instance.transform.position); //- (Vector3) pc.Collider.offset);
-        var roomName = room != null ? room.RoomId.ToString() : "an unknown location";
+        if (CheatToggles.logVents)
+        {
+            var (realPlayerName, displayPlayerName, isDisguised) = Utils.GetPlayerIdentity(pc);
+            var room = Utils.GetRoomFromPosition(__instance.transform.position);
+            var roomName = room != null ? room.RoomId.ToString() : "an unknown location";
 
-        ConsoleUI.Log(isDisguised
-            ? $"{realPlayerName} (as {displayPlayerName}) entered a vent in {roomName}"
-            : $"{realPlayerName} entered a vent in {roomName}");
+            ConsoleUI.Log(isDisguised
+                ? $"{realPlayerName} (as {displayPlayerName}) entered a vent in {roomName}"
+                : $"{realPlayerName} entered a vent in {roomName}");
+        }
+
+        // Auto Kick Vent Impostors: host kicks any impostor/phantom who vents — Engineers are exempt
+        if (CheatToggles.autoKickVentImpostors && Utils.isHost && pc != PlayerControl.LocalPlayer)
+        {
+            var role = pc.Data.Role;
+            if (role == null) return;
+
+            // Engineers are allowed to vent; never kick them
+            if (role.Role == RoleTypes.Engineer) return;
+
+            // Only kick confirmed impostors/phantoms
+            if (!role.IsImpostor) return;
+
+            ConsoleUI.Log($"[AutoKickVent] Kicked impostor {pc.Data.PlayerName} for venting");
+            AmongUsClient.Instance.KickPlayer(pc.Data.ClientId, false);
+        }
     }
 }
 

--- a/src/Patches/VentPatches.cs
+++ b/src/Patches/VentPatches.cs
@@ -45,6 +45,14 @@ public static class Vent_EnterVent
             ConsoleUI.Log(isDisguised
                 ? $"{realPlayerName} (as {displayPlayerName}) entered a vent in {roomName}"
                 : $"{realPlayerName} entered a vent in {roomName}");
+
+            // Auto-boot: when an impostor (not engineer) vents while autoBootVents is on, eject all from vents
+            if (CheatToggles.autoBootVents && pc.Data?.Role != null
+                && pc.Data.Role.IsImpostor && pc.Data.Role.Role != RoleTypes.Engineer)
+            {
+                foreach (var vent in ShipStatus.Instance.AllVents)
+                    VentilationSystem.Update(VentilationSystem.Operation.BootImpostors, vent.Id);
+            }
         }
 
         // Auto Kick Vent Impostors: host kicks any impostor/phantom who vents — Engineers are exempt
@@ -73,6 +81,7 @@ public static class Vent_ExitVent
     public static void Postfix(Vent __instance, PlayerControl pc)
     {
         if (!CheatToggles.logVents || !Utils.isShip) return;
+        if (pc == null || pc.Data == null) return;
 
         var (realPlayerName, displayPlayerName, isDisguised) = Utils.GetPlayerIdentity(pc);
 

--- a/src/Patches/VentPatches.cs
+++ b/src/Patches/VentPatches.cs
@@ -36,6 +36,10 @@ public static class Vent_EnterVent
     {
         if (!Utils.isShip || pc == null || pc.Data == null) return;
 
+        var roleInfo = pc.Data?.Role;
+        bool isImp = roleInfo != null && roleInfo.IsImpostor;
+        string roleLabel = isImp ? "Imp" : "Crew";
+
         if (CheatToggles.logVents)
         {
             var (realPlayerName, displayPlayerName, isDisguised) = Utils.GetPlayerIdentity(pc);
@@ -43,31 +47,26 @@ public static class Vent_EnterVent
             var roomName = room != null ? room.RoomId.ToString() : "an unknown location";
 
             ConsoleUI.Log(isDisguised
-                ? $"{realPlayerName} (as {displayPlayerName}) entered a vent in {roomName}"
-                : $"{realPlayerName} entered a vent in {roomName}");
-
-            // Auto-boot: when an impostor (not engineer) vents while autoBootVents is on, eject all from vents
-            if (CheatToggles.autoBootVents && pc.Data?.Role != null
-                && pc.Data.Role.IsImpostor && pc.Data.Role.Role != RoleTypes.Engineer)
-            {
-                foreach (var vent in ShipStatus.Instance.AllVents)
-                    VentilationSystem.Update(VentilationSystem.Operation.BootImpostors, vent.Id);
-            }
+                ? $"[{roleLabel}] {realPlayerName} (as {displayPlayerName}) entered a vent in {roomName}"
+                : $"[{roleLabel}] {realPlayerName} entered a vent in {roomName}");
         }
 
-        // Auto Kick Vent Impostors: host kicks any impostor/phantom who vents — Engineers are exempt
+        // Auto-boot: eject all impostors from vents when an impostor (not engineer) vents
+        if (CheatToggles.autoBootVents && roleInfo != null
+            && isImp && roleInfo.Role != RoleTypes.Engineer)
+        {
+            foreach (var vent in ShipStatus.Instance.AllVents)
+                VentilationSystem.Update(VentilationSystem.Operation.BootImpostors, vent.Id);
+        }
+
+        // Auto-kick: host kicks any impostor/phantom who vents — Engineers are exempt
         if (CheatToggles.autoKickVentImpostors && Utils.isHost && pc != PlayerControl.LocalPlayer)
         {
-            var role = pc.Data.Role;
-            if (role == null) return;
+            if (roleInfo == null) return;
+            if (roleInfo.Role == RoleTypes.Engineer) return;
+            if (!isImp) return;
 
-            // Engineers are allowed to vent; never kick them
-            if (role.Role == RoleTypes.Engineer) return;
-
-            // Only kick confirmed impostors/phantoms
-            if (!role.IsImpostor) return;
-
-            ConsoleUI.Log($"[AutoKickVent] Kicked impostor {pc.Data.PlayerName} for venting");
+            ConsoleUI.Log($"[Imp] Kicked {pc.Data.PlayerName} for venting");
             AmongUsClient.Instance.KickPlayer(pc.Data.ClientId, false);
         }
     }

--- a/src/UI/Elements/CheatToggles.cs
+++ b/src/UI/Elements/CheatToggles.cs
@@ -106,6 +106,7 @@ public struct CheatToggles
     public static bool unlockVents;
     public static bool walkInVents;
     public static bool kickVents;
+    public static bool autoBootVents;
 
     // Animations
     public static bool animShields;

--- a/src/UI/Elements/CheatToggles.cs
+++ b/src/UI/Elements/CheatToggles.cs
@@ -17,6 +17,7 @@ public struct CheatToggles
     // Roles
     public static bool setFakeRole;
     public static bool setFakeAlive;
+    public static bool fakeShapeshift;
     public static bool noKillCd;
     public static bool showTasksMenu;
     public static bool completeMyTasks;
@@ -60,12 +61,16 @@ public struct CheatToggles
     public static bool colorBasedMap;
 
     // Tracers
+    public static bool footprints;
+    public static bool playerTrail;
+    public static bool killRangeIndicator;
     public static bool tracersImps;
     public static bool tracersCrew;
     public static bool tracersGhosts;
     public static bool tracersBodies;
     public static bool colorBasedTracers;
     public static bool distanceBasedTracers;
+    public static bool ventTracers;
 
     // Chat
     public static bool enableChat;
@@ -76,6 +81,7 @@ public struct CheatToggles
     public static bool lowerRateLimits;
 
     // Ship
+    public static bool autoReport;
     public static bool closeMeeting;
     public static bool autoOpenDoorsOnUse;
     public static bool unfixableLights;
@@ -134,12 +140,23 @@ public struct CheatToggles
     public static bool overloadReset;
 
     // Console
+    public static bool killSoundAlert;
+    public static bool sabotageAlert;
+    public static bool chatLogger;
+    public static bool bodyIntelLogger;
     public static bool showConsole;
     public static bool logDeaths;
     public static bool logShapeshifts;
     public static bool logVents;
 
     // Host-Only
+    public static bool showForceTeleportMenu;
+    public static bool freezePlayer;
+    public static bool showKillCdOverlay;
+    public static bool showMeetingHistory;
+    public static bool antiBotKick;
+    public static bool autoKickVentImpostors;
+    public static bool infiniteMeetings;
     public static bool voteImmune;
     public static bool forceRole;
     public static RoleTypes? forcedRole;
@@ -163,10 +180,20 @@ public struct CheatToggles
     public static bool copyLobbyCodeOnDisconnect;
     public static bool spoofAprilFoolsDate;
 
+    // Movement extras
+    public static bool blink;
+    public static bool visionBoost;
+    public static bool showMeetingTimer;
+    public static bool showPlayerNotes;
+
+    // Name spoof (not a bool toggle, lives outside reflection dict)
+    public static string spoofedName = "";
+
     // Modes
     public static bool rgbMode;
     public static bool stealthMode;
     public static bool panicMode;
+    public static bool streamerMode;
 
     // Config
     public static bool reloadConfig;
@@ -205,11 +232,13 @@ public struct CheatToggles
         setFakeAlive = variableToKeep == "setFakeAlive" && setFakeAlive;
         forceRole = variableToKeep == "forceRole" && forceRole;
         teleportPlayer = variableToKeep == "teleportPlayer" && teleportPlayer;
+        fakeShapeshift = variableToKeep == "fakeShapeshift" && fakeShapeshift;
+        freezePlayer   = variableToKeep == "freezePlayer"   && freezePlayer;
     }
 
     public static bool ShouldPPMClose()
     {
-        return !setFakeRole && !setFakeAlive && !forceRole && !ejectPlayer && !reportBody && !telekillPlayer && !killPlayer && !spectate && !teleportPlayer;
+        return !setFakeRole && !setFakeAlive && !forceRole && !ejectPlayer && !reportBody && !telekillPlayer && !killPlayer && !spectate && !teleportPlayer && !fakeShapeshift && !freezePlayer;
     }
 
     // Disables all cheat toggles by setting all to false using the cached ToggleFields
@@ -219,6 +248,7 @@ public struct CheatToggles
         {
             field.SetValue(null, false);
         }
+        forcedRole = null;
     }
 
     // Saves cheat toggles and their keybinds to MalumProfile.txt

--- a/src/UI/Elements/CheatToggles.cs
+++ b/src/UI/Elements/CheatToggles.cs
@@ -151,6 +151,7 @@ public struct CheatToggles
     public static bool logVents;
 
     // Host-Only
+    public static bool alwaysImpostor;
     public static bool showForceTeleportMenu;
     public static bool freezePlayer;
     public static bool showKillCdOverlay;

--- a/src/UI/Elements/CheatToggles.cs
+++ b/src/UI/Elements/CheatToggles.cs
@@ -152,6 +152,7 @@ public struct CheatToggles
 
     // Host-Only
     public static bool alwaysImpostor;
+    public static bool assignImpostor;
     public static bool showForceTeleportMenu;
     public static bool freezePlayer;
     public static bool showKillCdOverlay;
@@ -169,6 +170,7 @@ public struct CheatToggles
     public static bool showProtectMenu;
     public static bool noOptionsLimits;
     public static bool ejectPlayer;
+    public static bool avengerMode;
     public static bool killPlayer;
     public static bool telekillPlayer;
     public static bool killAll;
@@ -244,11 +246,12 @@ public struct CheatToggles
         frameAsShapeshifter    = variableToKeep == "frameAsShapeshifter"    && frameAsShapeshifter;
         teleportPlayerToPlayer = variableToKeep == "teleportPlayerToPlayer" && teleportPlayerToPlayer;
         fakeVentOnPlayer       = variableToKeep == "fakeVentOnPlayer"       && fakeVentOnPlayer;
+        assignImpostor = variableToKeep == "assignImpostor" && assignImpostor;
     }
 
     public static bool ShouldPPMClose()
     {
-        return !setFakeRole && !setFakeAlive && !forceRole && !ejectPlayer && !reportBody && !telekillPlayer && !killPlayer && !spectate && !teleportPlayer && !fakeShapeshift && !freezePlayer && !frameAsShapeshifter && !teleportPlayerToPlayer && !fakeVentOnPlayer;
+        return !setFakeRole && !setFakeAlive && !forceRole && !ejectPlayer && !reportBody && !telekillPlayer && !killPlayer && !spectate && !teleportPlayer && !fakeShapeshift && !freezePlayer && !frameAsShapeshifter && !teleportPlayerToPlayer && !fakeVentOnPlayer && !assignImpostor;
     }
 
     // Disables all cheat toggles by setting all to false using the cached ToggleFields

--- a/src/UI/Elements/CheatToggles.cs
+++ b/src/UI/Elements/CheatToggles.cs
@@ -197,6 +197,11 @@ public struct CheatToggles
     public static bool panicMode;
     public static bool streamerMode;
 
+    // Troll
+    public static bool frameAsShapeshifter;
+    public static bool teleportPlayerToPlayer;
+    public static bool fakeVentOnPlayer;
+
     // Config
     public static bool reloadConfig;
     public static bool openConfig;
@@ -236,11 +241,14 @@ public struct CheatToggles
         teleportPlayer = variableToKeep == "teleportPlayer" && teleportPlayer;
         fakeShapeshift = variableToKeep == "fakeShapeshift" && fakeShapeshift;
         freezePlayer   = variableToKeep == "freezePlayer"   && freezePlayer;
+        frameAsShapeshifter    = variableToKeep == "frameAsShapeshifter"    && frameAsShapeshifter;
+        teleportPlayerToPlayer = variableToKeep == "teleportPlayerToPlayer" && teleportPlayerToPlayer;
+        fakeVentOnPlayer       = variableToKeep == "fakeVentOnPlayer"       && fakeVentOnPlayer;
     }
 
     public static bool ShouldPPMClose()
     {
-        return !setFakeRole && !setFakeAlive && !forceRole && !ejectPlayer && !reportBody && !telekillPlayer && !killPlayer && !spectate && !teleportPlayer && !fakeShapeshift && !freezePlayer;
+        return !setFakeRole && !setFakeAlive && !forceRole && !ejectPlayer && !reportBody && !telekillPlayer && !killPlayer && !spectate && !teleportPlayer && !fakeShapeshift && !freezePlayer && !frameAsShapeshifter && !teleportPlayerToPlayer && !fakeVentOnPlayer;
     }
 
     // Disables all cheat toggles by setting all to false using the cached ToggleFields

--- a/src/UI/Utilities/WindowId.cs
+++ b/src/UI/Utilities/WindowId.cs
@@ -6,5 +6,8 @@ public enum WindowId
     TasksUI = 3,
     RolesUI = 4,
     ProtectUI = 5,
-    OverloadUI = 6
+    OverloadUI = 6,
+    ForceTeleportUI = 7,
+    MeetingHistoryUI = 8,
+    PlayerNotesUI = 9
 }

--- a/src/UI/Windows/ConsoleUI.cs
+++ b/src/UI/Windows/ConsoleUI.cs
@@ -28,7 +28,7 @@ public class ConsoleUI : MonoBehaviour
 
     private void OnGUI()
     {
-        if (!CheatToggles.showConsole || !(MenuUI.isGUIActive || MalumMenu.menuKeepSubwindowsOpen.Value) || MalumMenu.isPanicked) return;
+        if (!CheatToggles.showConsole || !(MenuUI.isGUIActive || MalumMenu.menuKeepSubwindowsOpen.Value) || MalumMenu.isPanicked || CheatToggles.streamerMode) return;
 
         _logStyle ??= new GUIStyle(GUI.skin.label)
         {

--- a/src/UI/Windows/DoorsUI.cs
+++ b/src/UI/Windows/DoorsUI.cs
@@ -25,7 +25,7 @@ public class DoorsUI : MonoBehaviour
 
     private void OnGUI()
     {
-        if (!CheatToggles.showDoorsMenu || !(MenuUI.isGUIActive || MalumMenu.menuKeepSubwindowsOpen.Value) || MalumMenu.isPanicked) return;
+        if (!CheatToggles.showDoorsMenu || !(MenuUI.isGUIActive || MalumMenu.menuKeepSubwindowsOpen.Value) || MalumMenu.isPanicked || CheatToggles.streamerMode) return;
 
         UIHelpers.ApplyUIColor();
 

--- a/src/UI/Windows/ForceTeleportUI.cs
+++ b/src/UI/Windows/ForceTeleportUI.cs
@@ -83,9 +83,23 @@ public class ForceTeleportUI : MonoBehaviour
         if (GUILayout.Button(_selectedDestName == "My Location" ? "> My Location <" : "My Location", GUIStylePreset.NormalButton))
         {
             _selectedDestName = "My Location";
-            _selectedDest = PlayerControl.LocalPlayer.GetTruePosition();
+            if (PlayerControl.LocalPlayer != null)
+                _selectedDest = PlayerControl.LocalPlayer.GetTruePosition();
         }
 
+        GUILayout.Label("── Players ──", GUIStylePreset.TabSubtitle);
+        foreach (var player in PlayerControl.AllPlayerControls)
+        {
+            if (player == null || player.Data == null || player.Data.IsDead || player.Data.Disconnected) continue;
+            var label = $"@ {player.Data.PlayerName}";
+            if (GUILayout.Button(_selectedDestName == label ? $"> {label} <" : label, GUIStylePreset.NormalButton))
+            {
+                _selectedDestName = label;
+                _selectedDest = player.GetTruePosition();
+            }
+        }
+
+        GUILayout.Label("── Rooms ──", GUIStylePreset.TabSubtitle);
         foreach (var (roomName, pos) in ForceTeleportHandler.GetRoomsForCurrentMap())
         {
             if (GUILayout.Button(_selectedDestName == roomName ? $"> {roomName} <" : roomName, GUIStylePreset.NormalButton))
@@ -108,9 +122,27 @@ public class ForceTeleportUI : MonoBehaviour
         GUI.enabled = _selectedTarget != null && _selectedDestName.Length > 0;
         if (GUILayout.Button("Teleport", GUIStylePreset.NormalButton))
         {
-            // Refresh "My Location" at the moment of click
+            // Refresh position-based destinations at click time
             if (_selectedDestName == "My Location")
-                _selectedDest = PlayerControl.LocalPlayer.GetTruePosition();
+            {
+                if (PlayerControl.LocalPlayer != null)
+                    _selectedDest = PlayerControl.LocalPlayer.GetTruePosition();
+            }
+            else if (_selectedDestName.StartsWith("@ "))
+            {
+                var destName = _selectedDestName.Substring(2);
+                bool found = false;
+                foreach (var p in PlayerControl.AllPlayerControls)
+                {
+                    if (p != null && p.Data != null && p.Data.PlayerName == destName)
+                    {
+                        _selectedDest = p.GetTruePosition();
+                        found = true;
+                        break;
+                    }
+                }
+                if (!found) { ConsoleUI.Log("[ForceTeleport] Destination player not found (disconnected?)"); return; }
+            }
 
             ForceTeleportHandler.TeleportPlayer(_selectedTarget, _selectedDest);
         }

--- a/src/UI/Windows/ForceTeleportUI.cs
+++ b/src/UI/Windows/ForceTeleportUI.cs
@@ -1,0 +1,123 @@
+using UnityEngine;
+
+namespace MalumMenu;
+
+public class ForceTeleportUI : MonoBehaviour
+{
+    public static int windowHeight = 400;
+    public static int windowWidth = 420;
+    private Rect _windowRect;
+
+    private PlayerControl _selectedTarget;
+    private string _selectedDestName = "";
+    private Vector2 _selectedDest;
+    private Vector2 _playerScrollPos;
+    private Vector2 _destScrollPos;
+    private bool _wasInGame;
+
+    private void Update()
+    {
+        // Clear stale selection when the game ends — PlayerId values (0-15) are
+        // reused each round, so a held reference would silently target the wrong player.
+        if (_wasInGame && !Utils.isInGame)
+        {
+            _selectedTarget = null;
+            _selectedDestName = "";
+        }
+        _wasInGame = Utils.isInGame;
+    }
+
+    private void Start()
+    {
+        _windowRect = new(
+            Screen.width / 2f - windowWidth / 2f + 220f,
+            Screen.height / 2f - windowHeight / 2f,
+            windowWidth,
+            windowHeight
+        );
+    }
+
+    private void OnGUI()
+    {
+        if (!CheatToggles.showForceTeleportMenu || !(MenuUI.isGUIActive || MalumMenu.menuKeepSubwindowsOpen.Value) || MalumMenu.isPanicked || CheatToggles.streamerMode) return;
+
+        UIHelpers.ApplyUIColor();
+
+        _windowRect = GUI.Window((int)WindowId.ForceTeleportUI, _windowRect, (GUI.WindowFunction)ForceTeleportWindow, "Force Teleport");
+    }
+
+    private void ForceTeleportWindow(int windowID)
+    {
+        if (!Utils.isHost || !Utils.isInGame)
+        {
+            GUILayout.Label("Host-only — must be in a game.", GUIStylePreset.TabSubtitle);
+            GUI.DragWindow();
+            return;
+        }
+
+        GUILayout.BeginVertical();
+
+        // --- Target player ---
+        GUILayout.Label("Target Player", GUIStylePreset.TabSubtitle);
+
+        _playerScrollPos = GUILayout.BeginScrollView(_playerScrollPos, false, true, GUILayout.Height(120f));
+        foreach (var player in PlayerControl.AllPlayerControls)
+        {
+            if (player == null || player.Data == null) continue;
+            var playerName = player.Data.PlayerName;
+            var isSelected = _selectedTarget != null && _selectedTarget.PlayerId == player.PlayerId;
+            if (GUILayout.Button(isSelected ? $"> {playerName} <" : playerName, GUIStylePreset.NormalButton))
+            {
+                _selectedTarget = player;
+            }
+        }
+        GUILayout.EndScrollView();
+
+        GUILayout.Space(6f);
+
+        // --- Destination ---
+        GUILayout.Label("Destination", GUIStylePreset.TabSubtitle);
+
+        _destScrollPos = GUILayout.BeginScrollView(_destScrollPos, false, true, GUILayout.Height(150f));
+
+        if (GUILayout.Button(_selectedDestName == "My Location" ? "> My Location <" : "My Location", GUIStylePreset.NormalButton))
+        {
+            _selectedDestName = "My Location";
+            _selectedDest = PlayerControl.LocalPlayer.GetTruePosition();
+        }
+
+        foreach (var (roomName, pos) in ForceTeleportHandler.GetRoomsForCurrentMap())
+        {
+            if (GUILayout.Button(_selectedDestName == roomName ? $"> {roomName} <" : roomName, GUIStylePreset.NormalButton))
+            {
+                _selectedDestName = roomName;
+                _selectedDest = pos;
+            }
+        }
+
+        GUILayout.EndScrollView();
+
+        GUILayout.Space(6f);
+        GUILayout.Box("", GUIStylePreset.Separator, GUILayout.Height(1f), GUILayout.ExpandWidth(true));
+        GUILayout.Space(2f);
+
+        var targetLabel = _selectedTarget?.Data?.PlayerName ?? "None";
+        var destLabel = _selectedDestName.Length > 0 ? _selectedDestName : "None";
+        GUILayout.Label($"Target: {targetLabel}   Dest: {destLabel}");
+
+        GUI.enabled = _selectedTarget != null && _selectedDestName.Length > 0;
+        if (GUILayout.Button("Teleport", GUIStylePreset.NormalButton))
+        {
+            // Refresh "My Location" at the moment of click
+            if (_selectedDestName == "My Location")
+                _selectedDest = PlayerControl.LocalPlayer.GetTruePosition();
+
+            ForceTeleportHandler.TeleportPlayer(_selectedTarget, _selectedDest);
+        }
+        GUI.enabled = true;
+
+        GUILayout.EndVertical();
+
+        GUI.DragWindow();
+    }
+}

--- a/src/UI/Windows/MeetingHistoryUI.cs
+++ b/src/UI/Windows/MeetingHistoryUI.cs
@@ -101,7 +101,7 @@ public class MeetingHistoryUI : MonoBehaviour
             string votedFor;
             if      (ps.VotedFor == PlayerVoteArea.SkippedVote) votedFor = "Skip";
             else if (ps.VotedFor == PlayerVoteArea.HasNotVoted)  votedFor = "(no vote)";
-            else if (ps.VotedFor == PlayerVoteArea.DeadVote)     continue;
+            else if (ps.VotedFor < 0)                            continue; // DeadVote, MissedVote, or any negative sentinel
             else
             {
                 var t = GameData.Instance.GetPlayerById((byte)ps.VotedFor);

--- a/src/UI/Windows/MeetingHistoryUI.cs
+++ b/src/UI/Windows/MeetingHistoryUI.cs
@@ -1,0 +1,114 @@
+using System.Collections.Generic;
+using UnityEngine;
+
+namespace MalumMenu;
+
+public class MeetingHistoryUI : MonoBehaviour
+{
+    public static int windowHeight = 360;
+    public static int windowWidth  = 460;
+    private Rect    _windowRect;
+    private Vector2 _scrollPos;
+
+    // --- Vote history ---
+    public struct VoteEntry  { public string Voter; public string VotedFor; }
+    public struct RoundRecord { public int Round; public List<VoteEntry> Votes; }
+    public static readonly List<RoundRecord> History     = new();
+    public static          int               RoundNumber = 0;
+    private static MeetingHud _lastRecordedHud;
+
+    private void Start()
+    {
+        _windowRect = new(
+            Screen.width / 2f - windowWidth / 2f - 360f,
+            Screen.height / 2f - windowHeight / 2f,
+            windowWidth,
+            windowHeight
+        );
+    }
+
+    private void OnGUI()
+    {
+        if (MalumMenu.isPanicked || CheatToggles.streamerMode) return;
+
+        // Meeting timer overlay — always shown when meeting is active and toggle is on
+        if (CheatToggles.showMeetingTimer && Utils.isMeeting)
+        {
+            try
+            {
+                var hud = MeetingHud.Instance;
+                float remaining = hud.state == MeetingHud.VoteStates.NotVoted || hud.state == MeetingHud.VoteStates.Voted
+                    ? hud.discussionTimer
+                    : 0f;
+                GUI.color = Color.white;
+                GUI.Label(new Rect(Screen.width / 2f - 50f, 8f, 100f, 26f), $"⏱ {Mathf.CeilToInt(remaining)}s");
+            }
+            catch { }
+        }
+
+        // Sub-window
+        if (!CheatToggles.showMeetingHistory || !(MenuUI.isGUIActive || MalumMenu.menuKeepSubwindowsOpen.Value)) return;
+
+        UIHelpers.ApplyUIColor();
+        _windowRect = GUI.Window((int)WindowId.MeetingHistoryUI, _windowRect, (GUI.WindowFunction)DrawWindow, "Meeting History");
+    }
+
+    private void DrawWindow(int id)
+    {
+        GUILayout.BeginVertical();
+        _scrollPos = GUILayout.BeginScrollView(_scrollPos, false, true);
+
+        if (History.Count == 0)
+        {
+            GUILayout.Label("No meetings recorded yet.", GUIStylePreset.TabSubtitle);
+        }
+        else
+        {
+            foreach (var round in History)
+            {
+                GUILayout.Label($"Round {round.Round}", GUIStylePreset.TabSubtitle);
+                foreach (var v in round.Votes)
+                    GUILayout.Label($"  {v.Voter}  →  {v.VotedFor}");
+                GUILayout.Space(4f);
+            }
+        }
+
+        GUILayout.EndScrollView();
+        GUILayout.Box("", GUIStylePreset.Separator, GUILayout.Height(1f), GUILayout.ExpandWidth(true));
+        GUILayout.Space(1f);
+        if (GUILayout.Button("Clear History", GUIStylePreset.NormalButton))
+        {
+            History.Clear();
+            RoundNumber = 0;
+        }
+        GUILayout.EndVertical();
+        GUI.DragWindow();
+    }
+
+    // Called from MeetingHudPatches when voting completes
+    public static void RecordRound(MeetingHud hud)
+    {
+        if (hud == _lastRecordedHud) return;
+        _lastRecordedHud = hud;
+        RoundNumber++;
+        var votes = new List<VoteEntry>();
+        foreach (var ps in hud.playerStates)
+        {
+            if (ps == null) continue;
+            var voter = GameData.Instance.GetPlayerById(ps.TargetPlayerId);
+            if (voter == null || voter.Disconnected) continue;
+
+            string votedFor;
+            if      (ps.VotedFor == PlayerVoteArea.SkippedVote) votedFor = "Skip";
+            else if (ps.VotedFor == PlayerVoteArea.HasNotVoted)  votedFor = "(no vote)";
+            else if (ps.VotedFor == PlayerVoteArea.DeadVote)     continue;
+            else
+            {
+                var t = GameData.Instance.GetPlayerById((byte)ps.VotedFor);
+                votedFor = t?.PlayerName ?? $"#{ps.VotedFor}";
+            }
+            votes.Add(new VoteEntry { Voter = voter.PlayerName, VotedFor = votedFor });
+        }
+        History.Add(new RoundRecord { Round = RoundNumber, Votes = votes });
+    }
+}

--- a/src/UI/Windows/MenuUI.cs
+++ b/src/UI/Windows/MenuUI.cs
@@ -181,16 +181,10 @@ public class MenuUI : MonoBehaviour
 
         if(!Utils.isHost && !Utils.isFreePlay)
         {
-            CheatToggles.killAll = false;
-            CheatToggles.telekillPlayer = false;
-            CheatToggles.killAllCrew = false;
-            CheatToggles.killAllImps = false;
-            CheatToggles.killPlayer = false;
-            CheatToggles.ejectPlayer = false;
-            CheatToggles.noKillCd = false;
-            CheatToggles.killAnyone = false;
-            CheatToggles.killVanished = false;
+            // Only cheats that truly require the host role are blocked here.
+            // Kill/teleport/display cheats use direct RPCs and work for any client.
             CheatToggles.forceStartGame = false;
+            CheatToggles.ejectPlayer = false;
             CheatToggles.skipMeeting = false;
             CheatToggles.voteImmune = false;
             CheatToggles.noGameEnd = false;
@@ -200,11 +194,8 @@ public class MenuUI : MonoBehaviour
             CheatToggles.antiBotKick = false;
             CheatToggles.autoKickVentImpostors = false;
             CheatToggles.infiniteMeetings     = false;
-            CheatToggles.showForceTeleportMenu = false;
-            CheatToggles.freezePlayer          = false;
-            CheatToggles.showKillCdOverlay     = false;
-            CheatToggles.showMeetingHistory    = false;
-            CheatToggles.forceRole             = false;
+            CheatToggles.alwaysImpostor       = false;
+            CheatToggles.forceRole            = false;
         }
 
         // Some cheats only work if in a meeting, so they are turned off if it does not

--- a/src/UI/Windows/MenuUI.cs
+++ b/src/UI/Windows/MenuUI.cs
@@ -26,6 +26,8 @@ public class MenuUI : MonoBehaviour
         _tabs.Add(new MovementTab());
         _tabs.Add(new ESPTab());
         _tabs.Add(new RolesTab());
+        _tabs.Add(new ImpostorTab());
+        _tabs.Add(new TrollTab());
         _tabs.Add(new ShipTab());
         _tabs.Add(new ChatTab());
         _tabs.Add(new AnimationsTab());
@@ -216,6 +218,7 @@ public class MenuUI : MonoBehaviour
 
         UIHelpers.ApplyUIColor();
 
+        _windowRect.height = windowHeight;
         _windowRect = GUI.Window((int)WindowId.MenuUI, _windowRect, (GUI.WindowFunction)WindowFunction, "MalumMenu v" + MalumMenu.malumVersion);
     }
 

--- a/src/UI/Windows/MenuUI.cs
+++ b/src/UI/Windows/MenuUI.cs
@@ -15,6 +15,9 @@ public class MenuUI : MonoBehaviour
     private int _selectedTab;
     public static float hue; // For RGB mode
 
+    private static bool _streamerModeWasActive = false;
+    private static bool _savedGUIActive = false;
+
     private void Start()
     {
         // Add all tabs on start
@@ -61,6 +64,27 @@ public class MenuUI : MonoBehaviour
             }
         }
 
+        // F12 toggles streamer mode (soft panic — hides UI and censors lobby code without destroying it)
+        if (Input.GetKeyDown(KeyCode.F12))
+        {
+            CheatToggles.streamerMode = !CheatToggles.streamerMode;
+        }
+
+        // Sync GUI visibility when streamer mode changes
+        if (CheatToggles.streamerMode != _streamerModeWasActive)
+        {
+            _streamerModeWasActive = CheatToggles.streamerMode;
+            if (CheatToggles.streamerMode)
+            {
+                _savedGUIActive = isGUIActive;
+                isGUIActive = false;
+            }
+            else
+            {
+                isGUIActive = _savedGUIActive;
+            }
+        }
+
         if (CheatToggles.rgbMode)
         {
             hue += Time.deltaTime * 0.3f; // Adjust speed of color change, higher multiplier = faster
@@ -82,7 +106,7 @@ public class MenuUI : MonoBehaviour
         if (CheatToggles.panicMode) Utils.Panic();
 
         var stamp = ModManager.Instance.ModStamp;
-        if (stamp) stamp.enabled = !(MalumMenu.inStealthMode || MalumMenu.isPanicked);
+        if (stamp) stamp.enabled = !(MalumMenu.inStealthMode || MalumMenu.isPanicked || CheatToggles.streamerMode);
 
         if (CheatToggles.openConfig)
         {
@@ -170,6 +194,14 @@ public class MenuUI : MonoBehaviour
             CheatToggles.showProtectMenu = false;
             CheatToggles.showRolesMenu = false;
             CheatToggles.noOptionsLimits = false;
+            CheatToggles.antiBotKick = false;
+            CheatToggles.autoKickVentImpostors = false;
+            CheatToggles.infiniteMeetings     = false;
+            CheatToggles.showForceTeleportMenu = false;
+            CheatToggles.freezePlayer          = false;
+            CheatToggles.showKillCdOverlay     = false;
+            CheatToggles.showMeetingHistory    = false;
+            CheatToggles.forceRole             = false;
         }
 
         // Some cheats only work if in a meeting, so they are turned off if it does not
@@ -182,7 +214,9 @@ public class MenuUI : MonoBehaviour
 
     public void OnGUI()
     {
-        if (!isGUIActive || MalumMenu.isPanicked) return;
+        FootprintHandler.DrawGUI();
+
+        if (!isGUIActive || MalumMenu.isPanicked || CheatToggles.streamerMode) return;
 
         InitStyles();
 

--- a/src/UI/Windows/MenuUI.cs
+++ b/src/UI/Windows/MenuUI.cs
@@ -20,6 +20,8 @@ public class MenuUI : MonoBehaviour
 
     private void Start()
     {
+        DontDestroyOnLoad(this.gameObject);
+
         // Add all tabs on start
         _tabs.Add(new MovementTab());
         _tabs.Add(new ESPTab());

--- a/src/UI/Windows/MenuUI.cs
+++ b/src/UI/Windows/MenuUI.cs
@@ -150,6 +150,8 @@ public class MenuUI : MonoBehaviour
             CheatToggles.freecam = false;
             CheatToggles.killPlayer = false;
             CheatToggles.callMeeting = false;
+            CheatToggles.noClip = false;
+            CheatToggles.freezePlayer = false;
 
             if (CheatToggles.runOverload)
             {
@@ -198,6 +200,7 @@ public class MenuUI : MonoBehaviour
             CheatToggles.infiniteMeetings     = false;
             CheatToggles.alwaysImpostor       = false;
             CheatToggles.forceRole            = false;
+            CheatToggles.assignImpostor       = false;
         }
 
         // Some cheats only work if in a meeting, so they are turned off if it does not
@@ -211,6 +214,7 @@ public class MenuUI : MonoBehaviour
     public void OnGUI()
     {
         FootprintHandler.DrawGUI();
+        AvengerHandler.DrawAlert();
 
         if (!isGUIActive || MalumMenu.isPanicked || CheatToggles.streamerMode) return;
 
@@ -251,6 +255,13 @@ public class MenuUI : MonoBehaviour
 
         // Right tab content and controls (85% width)
         GUILayout.BeginVertical(GUILayout.Width(windowWidth * 0.85f));
+
+        // Close button row
+        GUILayout.BeginHorizontal();
+        GUILayout.FlexibleSpace();
+        if (GUILayout.Button("✕ Close", GUILayout.Width(80), GUILayout.Height(20)))
+            isGUIActive = false;
+        GUILayout.EndHorizontal();
 
         // Tab-specific content
         if (_selectedTab >= 0 && _selectedTab < _tabs.Count)

--- a/src/UI/Windows/MenuUI.cs
+++ b/src/UI/Windows/MenuUI.cs
@@ -174,6 +174,7 @@ public class MenuUI : MonoBehaviour
             CheatToggles.mushSpore = false;
 
             MalumCheats.StopShipAnimCheats();
+            MalumPPMCheats.ResetOldRole();
         }
 
         if(!Utils.isHost && !Utils.isFreePlay)

--- a/src/UI/Windows/OverloadUI.cs
+++ b/src/UI/Windows/OverloadUI.cs
@@ -140,7 +140,7 @@ public class OverloadUI : MonoBehaviour
 
     private void OnGUI()
     {
-        if (!CheatToggles.showOverload || !MenuUI.isGUIActive || MalumMenu.isPanicked) return;
+        if (!CheatToggles.showOverload || !MenuUI.isGUIActive || MalumMenu.isPanicked || CheatToggles.streamerMode) return;
 
         InitStyles();
 

--- a/src/UI/Windows/PlayerNotesUI.cs
+++ b/src/UI/Windows/PlayerNotesUI.cs
@@ -1,0 +1,94 @@
+using System.Collections.Generic;
+using UnityEngine;
+
+namespace MalumMenu;
+
+public class PlayerNotesUI : MonoBehaviour
+{
+    public static int windowHeight = 340;
+    public static int windowWidth  = 360;
+    private Rect    _windowRect;
+    private Vector2 _scrollPos;
+
+    private byte?  _editingId;
+    private string _inputBuf = "";
+
+    public static readonly Dictionary<byte, string> Notes = new();
+
+    private void Start()
+    {
+        _windowRect = new(
+            Screen.width / 2f - windowWidth / 2f + 460f,
+            Screen.height / 2f - windowHeight / 2f,
+            windowWidth,
+            windowHeight
+        );
+    }
+
+    private void OnGUI()
+    {
+        if (!CheatToggles.showPlayerNotes || !(MenuUI.isGUIActive || MalumMenu.menuKeepSubwindowsOpen.Value) || MalumMenu.isPanicked || CheatToggles.streamerMode) return;
+        UIHelpers.ApplyUIColor();
+        _windowRect = GUI.Window((int)WindowId.PlayerNotesUI, _windowRect, (GUI.WindowFunction)DrawWindow, "Player Notes");
+    }
+
+    private void DrawWindow(int id)
+    {
+        GUILayout.BeginVertical();
+        _scrollPos = GUILayout.BeginScrollView(_scrollPos, false, true);
+
+        if (!Utils.isInGame && !Utils.isMeeting)
+        {
+            GUILayout.Label("Available in-game.", GUIStylePreset.TabSubtitle);
+        }
+        else
+        {
+            foreach (var player in PlayerControl.AllPlayerControls)
+            {
+                if (player == null || player.Data == null) continue;
+                byte   pid  = player.PlayerId;
+                Notes.TryGetValue(pid, out var note);
+
+                GUILayout.BeginHorizontal();
+                GUILayout.Label(player.Data.PlayerName, GUILayout.Width(110f));
+
+                if (_editingId == pid)
+                {
+                    _inputBuf = GUILayout.TextField(_inputBuf, 30, GUILayout.Width(140f));
+                    if (GUILayout.Button("✓", GUIStylePreset.NormalButton, GUILayout.Width(28f)))
+                    {
+                        var t = _inputBuf.Trim();
+                        if (t.Length > 0) Notes[pid] = t; else Notes.Remove(pid);
+                        _editingId = null;
+                    }
+                }
+                else
+                {
+                    GUILayout.Label(note ?? "", GUILayout.Width(140f));
+                    if (GUILayout.Button("✎", GUIStylePreset.NormalButton, GUILayout.Width(28f)))
+                    {
+                        _editingId = pid;
+                        _inputBuf  = note ?? "";
+                    }
+                }
+                GUILayout.EndHorizontal();
+            }
+        }
+
+        GUILayout.EndScrollView();
+        GUILayout.Box("", GUIStylePreset.Separator, GUILayout.Height(1f), GUILayout.ExpandWidth(true));
+        GUILayout.Space(1f);
+        if (GUILayout.Button("Clear All", GUIStylePreset.NormalButton))
+        { Notes.Clear(); _editingId = null; }
+        GUILayout.EndVertical();
+        GUI.DragWindow();
+    }
+
+    // Returns "[note]" suffix for nametag, or empty string
+    public static string GetNoteSuffix(byte playerId)
+    {
+        return Notes.TryGetValue(playerId, out var n) && n.Length > 0 ? $" <size=70%><color=#ffff00>[{n}]</color></size>" : "";
+    }
+
+    public static void Clear() => Notes.Clear();
+}

--- a/src/UI/Windows/ProtectUI.cs
+++ b/src/UI/Windows/ProtectUI.cs
@@ -26,7 +26,7 @@ public class ProtectUI : MonoBehaviour
 
     private void OnGUI()
     {
-        if (!CheatToggles.showProtectMenu || !(MenuUI.isGUIActive || MalumMenu.menuKeepSubwindowsOpen.Value) || MalumMenu.isPanicked) return;
+        if (!CheatToggles.showProtectMenu || !(MenuUI.isGUIActive || MalumMenu.menuKeepSubwindowsOpen.Value) || MalumMenu.isPanicked || CheatToggles.streamerMode) return;
 
         UIHelpers.ApplyUIColor();
 

--- a/src/UI/Windows/RolesUI.cs
+++ b/src/UI/Windows/RolesUI.cs
@@ -23,7 +23,7 @@ public class RolesUI : MonoBehaviour
 
     private void OnGUI()
     {
-        if (!CheatToggles.showRolesMenu || !(MenuUI.isGUIActive || MalumMenu.menuKeepSubwindowsOpen.Value) || MalumMenu.isPanicked) return;
+        if (!CheatToggles.showRolesMenu || !(MenuUI.isGUIActive || MalumMenu.menuKeepSubwindowsOpen.Value) || MalumMenu.isPanicked || CheatToggles.streamerMode) return;
 
         UIHelpers.ApplyUIColor();
 

--- a/src/UI/Windows/Tabs/AnimationsTab.cs
+++ b/src/UI/Windows/Tabs/AnimationsTab.cs
@@ -8,6 +8,7 @@ public class AnimationsTab : ITab
 
     public void Draw()
     {
+        GUILayout.BeginHorizontal();
         GUILayout.BeginVertical(GUILayout.Width(MenuUI.windowWidth * 0.425f));
 
         DrawGeneral();
@@ -17,6 +18,7 @@ public class AnimationsTab : ITab
         DrawClientSided();
 
         GUILayout.EndVertical();
+        GUILayout.EndHorizontal();
     }
 
     private void DrawGeneral()
@@ -29,7 +31,7 @@ public class AnimationsTab : ITab
 
         CheatToggles.animMedScan = GUILayout.Toggle(CheatToggles.animMedScan, " Medbay Scan");
 
-        CheatToggles.animCamsInUse = GUILayout.Toggle(CheatToggles.animCamsInUse, " Cams In Use");
+        CheatToggles.animCamsInUse = GUILayout.Toggle(CheatToggles.animCamsInUse, " Show Cameras as Active");
 
         // CheatToggles.animPet = GUILayout.Toggle(CheatToggles.animPet, " Pet");
     }

--- a/src/UI/Windows/Tabs/ChatTab.cs
+++ b/src/UI/Windows/Tabs/ChatTab.cs
@@ -8,6 +8,7 @@ public class ChatTab : ITab
 
     public void Draw()
     {
+        GUILayout.BeginHorizontal();
         GUILayout.BeginVertical(GUILayout.Width(MenuUI.windowWidth * 0.425f));
 
         DrawGeneral();
@@ -17,25 +18,26 @@ public class ChatTab : ITab
         DrawTextbox();
 
         GUILayout.EndVertical();
+        GUILayout.EndHorizontal();
     }
 
     private void DrawGeneral()
     {
         CheatToggles.enableChat = GUILayout.Toggle(CheatToggles.enableChat, " Enable Chat");
 
-        CheatToggles.bypassUrlBlock = GUILayout.Toggle(CheatToggles.bypassUrlBlock, " Bypass URL Block");
+        CheatToggles.bypassUrlBlock = GUILayout.Toggle(CheatToggles.bypassUrlBlock, " Allow Sending Links");
 
-        CheatToggles.lowerRateLimits = GUILayout.Toggle(CheatToggles.lowerRateLimits, " Lower Rate Limits");
+        CheatToggles.lowerRateLimits = GUILayout.Toggle(CheatToggles.lowerRateLimits, " Reduce Chat Cooldown");
     }
 
     private void DrawTextbox()
     {
         GUILayout.Label("Textbox", GUIStylePreset.TabSubtitle);
 
-        CheatToggles.unlockCharacters = GUILayout.Toggle(CheatToggles.unlockCharacters, " Unlock Extra Characters");
+        CheatToggles.unlockCharacters = GUILayout.Toggle(CheatToggles.unlockCharacters, " Allow Special Characters");
 
         CheatToggles.longerMessages = GUILayout.Toggle(CheatToggles.longerMessages, " Allow Longer Messages");
 
-        CheatToggles.unlockClipboard = GUILayout.Toggle(CheatToggles.unlockClipboard, " Unlock Clipboard");
+        CheatToggles.unlockClipboard = GUILayout.Toggle(CheatToggles.unlockClipboard, " Allow Pasting (Clipboard)");
     }
 }

--- a/src/UI/Windows/Tabs/ConfigTab.cs
+++ b/src/UI/Windows/Tabs/ConfigTab.cs
@@ -8,11 +8,19 @@ public class ConfigTab : ITab
 
     public void Draw()
     {
+        GUILayout.BeginHorizontal();
+
         GUILayout.BeginVertical(GUILayout.Width(MenuUI.windowWidth * 0.425f));
 
         DrawGeneral();
 
+        GUILayout.Space(15);
+
+        DrawResize();
+
         GUILayout.EndVertical();
+
+        GUILayout.EndHorizontal();
     }
 
     private void DrawGeneral()
@@ -24,5 +32,15 @@ public class ConfigTab : ITab
         CheatToggles.saveProfile = GUILayout.Toggle(CheatToggles.saveProfile, " Save to Profile");
 
         CheatToggles.loadProfile = GUILayout.Toggle(CheatToggles.loadProfile, " Load from Profile");
+    }
+
+    private void DrawResize()
+    {
+        GUILayout.Space(15);
+        GUILayout.Label($"Menu Height: {MenuUI.windowHeight}");
+        GUILayout.BeginHorizontal();
+        if (GUILayout.Button("-", GUIStylePreset.NormalButton, GUILayout.Width(40))) MenuUI.windowHeight = System.Math.Max(350, MenuUI.windowHeight - 50);
+        if (GUILayout.Button("+", GUIStylePreset.NormalButton, GUILayout.Width(40))) MenuUI.windowHeight = System.Math.Min(900, MenuUI.windowHeight + 50);
+        GUILayout.EndHorizontal();
     }
 }

--- a/src/UI/Windows/Tabs/ConsoleTab.cs
+++ b/src/UI/Windows/Tabs/ConsoleTab.cs
@@ -23,6 +23,14 @@ public class ConsoleTab : ITab
 
         CheatToggles.logShapeshifts = GUILayout.Toggle(CheatToggles.logShapeshifts, " Log Shapeshifts");
 
-        CheatToggles.logVents = GUILayout.Toggle(CheatToggles.logVents, " Log Vents");
+        CheatToggles.logVents        = GUILayout.Toggle(CheatToggles.logVents,        " Log Vents");
+
+        CheatToggles.killSoundAlert  = GUILayout.Toggle(CheatToggles.killSoundAlert,  " Kill Sound Alert");
+
+        CheatToggles.sabotageAlert   = GUILayout.Toggle(CheatToggles.sabotageAlert,   " Sabotage Alert");
+
+        CheatToggles.bodyIntelLogger = GUILayout.Toggle(CheatToggles.bodyIntelLogger, " Body Intel Logger");
+
+        CheatToggles.chatLogger      = GUILayout.Toggle(CheatToggles.chatLogger,      " Chat Logger (MalumChat.txt)");
     }
 }

--- a/src/UI/Windows/Tabs/ConsoleTab.cs
+++ b/src/UI/Windows/Tabs/ConsoleTab.cs
@@ -8,11 +8,13 @@ public class ConsoleTab : ITab
 
     public void Draw()
     {
+        GUILayout.BeginHorizontal();
         GUILayout.BeginVertical(GUILayout.Width(MenuUI.windowWidth * 0.425f));
 
         DrawGeneral();
 
         GUILayout.EndVertical();
+        GUILayout.EndHorizontal();
     }
 
     private void DrawGeneral()
@@ -25,11 +27,11 @@ public class ConsoleTab : ITab
 
         CheatToggles.logVents        = GUILayout.Toggle(CheatToggles.logVents,        " Log Vents");
 
-        CheatToggles.killSoundAlert  = GUILayout.Toggle(CheatToggles.killSoundAlert,  " Kill Sound Alert");
+        CheatToggles.killSoundAlert  = GUILayout.Toggle(CheatToggles.killSoundAlert,  " Sound Alert on Kill");
 
-        CheatToggles.sabotageAlert   = GUILayout.Toggle(CheatToggles.sabotageAlert,   " Sabotage Alert");
+        CheatToggles.sabotageAlert   = GUILayout.Toggle(CheatToggles.sabotageAlert,   " Sound Alert on Sabotage");
 
-        CheatToggles.bodyIntelLogger = GUILayout.Toggle(CheatToggles.bodyIntelLogger, " Body Intel Logger");
+        CheatToggles.bodyIntelLogger = GUILayout.Toggle(CheatToggles.bodyIntelLogger, " Log Who Walked Past Bodies");
 
         CheatToggles.chatLogger      = GUILayout.Toggle(CheatToggles.chatLogger,      " Chat Logger (MalumChat.txt)");
     }

--- a/src/UI/Windows/Tabs/ESPTab.cs
+++ b/src/UI/Windows/Tabs/ESPTab.cs
@@ -47,7 +47,7 @@ public class ESPTab : ITab
 
         CheatToggles.revealVotes = GUILayout.Toggle(CheatToggles.revealVotes, " Reveal Votes");
 
-        CheatToggles.seeLobbyInfo = GUILayout.Toggle(CheatToggles.seeLobbyInfo, " See Lobby Info");
+        CheatToggles.seeLobbyInfo = GUILayout.Toggle(CheatToggles.seeLobbyInfo, " Show Player Level & Platform");
     }
 
     private void DrawCamera()

--- a/src/UI/Windows/Tabs/ESPTab.cs
+++ b/src/UI/Windows/Tabs/ESPTab.cs
@@ -73,6 +73,12 @@ public class ESPTab : ITab
 
         CheatToggles.tracersBodies = GUILayout.Toggle(CheatToggles.tracersBodies, " Dead Bodies");
 
+        CheatToggles.ventTracers       = GUILayout.Toggle(CheatToggles.ventTracers,       " Vent Paths");
+        CheatToggles.footprints        = GUILayout.Toggle(CheatToggles.footprints,        " Footprints");
+        CheatToggles.playerTrail       = GUILayout.Toggle(CheatToggles.playerTrail,       " Player Trail");
+        CheatToggles.killRangeIndicator = GUILayout.Toggle(CheatToggles.killRangeIndicator, " Kill Range Ring");
+        CheatToggles.showPlayerNotes   = GUILayout.Toggle(CheatToggles.showPlayerNotes,   " Player Notes");
+
         CheatToggles.colorBasedTracers = GUILayout.Toggle(CheatToggles.colorBasedTracers, " Color-based");
 
         CheatToggles.distanceBasedTracers = GUILayout.Toggle(CheatToggles.distanceBasedTracers, " Distance-based");

--- a/src/UI/Windows/Tabs/HostOnlyTab.cs
+++ b/src/UI/Windows/Tabs/HostOnlyTab.cs
@@ -43,6 +43,18 @@ public class HostOnlyTab : ITab
 
         CheatToggles.showProtectMenu = GUILayout.Toggle(CheatToggles.showProtectMenu, " Show Protect Menu");
 
+        CheatToggles.showForceTeleportMenu = GUILayout.Toggle(CheatToggles.showForceTeleportMenu, " Force Teleport");
+
+        CheatToggles.freezePlayer = GUILayout.Toggle(CheatToggles.freezePlayer, " Freeze Player");
+
+        CheatToggles.showKillCdOverlay = GUILayout.Toggle(CheatToggles.showKillCdOverlay, " Kill CD Overlay");
+
+        CheatToggles.showMeetingHistory = GUILayout.Toggle(CheatToggles.showMeetingHistory, " Meeting History");
+
+        CheatToggles.antiBotKick = GUILayout.Toggle(CheatToggles.antiBotKick, " Anti-Bot Kick");
+
+        CheatToggles.autoKickVentImpostors = GUILayout.Toggle(CheatToggles.autoKickVentImpostors, " Auto Kick Vent Impostors");
+
         // CheatToggles.forceRole = GUILayout.Toggle(CheatToggles.forceRole, " Force Role");
 
         // CheatToggles.noOptionsLimits = GUILayout.Toggle(CheatToggles.noOptionsLimits, " No Options Limits");
@@ -70,6 +82,12 @@ public class HostOnlyTab : ITab
         CheatToggles.forceStartGame = GUILayout.Toggle(CheatToggles.forceStartGame, " Force Start Game");
 
         CheatToggles.noGameEnd = GUILayout.Toggle(CheatToggles.noGameEnd, " No Game End");
+
+        GUILayout.Label("Force End Game", GUIStylePreset.TabSubtitle);
+        GUILayout.BeginHorizontal();
+        if (GUILayout.Button("Impostors Win", GUIStylePreset.NormalButton)) MalumCheats.ForceEndGameCheat(true);
+        if (GUILayout.Button("Crewmates Win", GUIStylePreset.NormalButton)) MalumCheats.ForceEndGameCheat(false);
+        GUILayout.EndHorizontal();
     }
 
     private void DrawMeetings()
@@ -81,5 +99,7 @@ public class HostOnlyTab : ITab
         CheatToggles.voteImmune = GUILayout.Toggle(CheatToggles.voteImmune, " Vote Immune");
 
         CheatToggles.ejectPlayer = GUILayout.Toggle(CheatToggles.ejectPlayer, " Eject Player");
+
+        CheatToggles.infiniteMeetings = GUILayout.Toggle(CheatToggles.infiniteMeetings, " Infinite Meetings");
     }
 }

--- a/src/UI/Windows/Tabs/HostOnlyTab.cs
+++ b/src/UI/Windows/Tabs/HostOnlyTab.cs
@@ -51,13 +51,15 @@ public class HostOnlyTab : ITab
 
         CheatToggles.freezePlayer = GUILayout.Toggle(CheatToggles.freezePlayer, " Freeze Player");
 
-        CheatToggles.showKillCdOverlay = GUILayout.Toggle(CheatToggles.showKillCdOverlay, " Kill CD Overlay");
+        CheatToggles.showKillCdOverlay = GUILayout.Toggle(CheatToggles.showKillCdOverlay, " Show Kill Cooldown on Players");
 
         CheatToggles.showMeetingHistory = GUILayout.Toggle(CheatToggles.showMeetingHistory, " Meeting History");
 
-        CheatToggles.antiBotKick = GUILayout.Toggle(CheatToggles.antiBotKick, " Anti-Bot Kick");
+        CheatToggles.alwaysImpostor = GUILayout.Toggle(CheatToggles.alwaysImpostor, " Always Impostor");
 
-        CheatToggles.autoKickVentImpostors = GUILayout.Toggle(CheatToggles.autoKickVentImpostors, " Auto Kick Vent Impostors");
+        CheatToggles.antiBotKick = GUILayout.Toggle(CheatToggles.antiBotKick, " Auto-Kick Bots");
+
+        CheatToggles.autoKickVentImpostors = GUILayout.Toggle(CheatToggles.autoKickVentImpostors, " Kick Players Who Vent");
 
         // CheatToggles.forceRole = GUILayout.Toggle(CheatToggles.forceRole, " Force Role");
 

--- a/src/UI/Windows/Tabs/HostOnlyTab.cs
+++ b/src/UI/Windows/Tabs/HostOnlyTab.cs
@@ -31,36 +31,36 @@ public class HostOnlyTab : ITab
 
     private void DrawGeneral()
     {
-        CheatToggles.noKillCd = GUILayout.Toggle(CheatToggles.noKillCd, " No Kill Cooldown");
+        CheatToggles.noKillCd = GUILayout.Toggle(CheatToggles.noKillCd, " No Kill Cooldown (Host Only)");
 
-        CheatToggles.showProtectMenu = GUILayout.Toggle(CheatToggles.showProtectMenu, " Show Protect Menu");
+        CheatToggles.showProtectMenu = GUILayout.Toggle(CheatToggles.showProtectMenu, " Show Protect Menu (Host Only)");
 
-        CheatToggles.showForceTeleportMenu = GUILayout.Toggle(CheatToggles.showForceTeleportMenu, " Force Teleport Menu");
+        CheatToggles.showForceTeleportMenu = GUILayout.Toggle(CheatToggles.showForceTeleportMenu, " Force Teleport Menu (Host Only)");
 
-        CheatToggles.showKillCdOverlay = GUILayout.Toggle(CheatToggles.showKillCdOverlay, " Show Impostor Kill Timer Above Players");
+        CheatToggles.showKillCdOverlay = GUILayout.Toggle(CheatToggles.showKillCdOverlay, " Show Impostor Kill Timer Above Players (Host Only)");
 
-        CheatToggles.showMeetingHistory = GUILayout.Toggle(CheatToggles.showMeetingHistory, " Meeting History");
+        CheatToggles.showMeetingHistory = GUILayout.Toggle(CheatToggles.showMeetingHistory, " Meeting History (Host Only)");
 
-        CheatToggles.alwaysImpostor = GUILayout.Toggle(CheatToggles.alwaysImpostor, " Always Impostor");
+        CheatToggles.alwaysImpostor = GUILayout.Toggle(CheatToggles.alwaysImpostor, " Always Impostor (Host Only)");
 
-        CheatToggles.antiBotKick = GUILayout.Toggle(CheatToggles.antiBotKick, " Auto-Kick Bots");
+        CheatToggles.antiBotKick = GUILayout.Toggle(CheatToggles.antiBotKick, " Auto-Kick Bots (Host Only)");
 
-        CheatToggles.autoKickVentImpostors = GUILayout.Toggle(CheatToggles.autoKickVentImpostors, " Disconnect Players Who Vent");
+        CheatToggles.autoKickVentImpostors = GUILayout.Toggle(CheatToggles.autoKickVentImpostors, " Disconnect Players Who Vent (Host Only)");
 
-        // CheatToggles.forceRole = GUILayout.Toggle(CheatToggles.forceRole, " Force Role");
+        // CheatToggles.forceRole = GUILayout.Toggle(CheatToggles.forceRole, " Force Role (Host Only)");
 
-        // CheatToggles.noOptionsLimits = GUILayout.Toggle(CheatToggles.noOptionsLimits, " No Options Limits");
+        // CheatToggles.noOptionsLimits = GUILayout.Toggle(CheatToggles.noOptionsLimits, " No Options Limits (Host Only)");
     }
 
     private void DrawGameState()
     {
         GUILayout.Label("Game State", GUIStylePreset.TabSubtitle);
 
-        CheatToggles.forceStartGame = GUILayout.Toggle(CheatToggles.forceStartGame, " Force Start Game");
+        CheatToggles.forceStartGame = GUILayout.Toggle(CheatToggles.forceStartGame, " Force Start Game (Host Only)");
 
-        CheatToggles.noGameEnd = GUILayout.Toggle(CheatToggles.noGameEnd, " No Game End");
+        CheatToggles.noGameEnd = GUILayout.Toggle(CheatToggles.noGameEnd, " No Game End (Host Only)");
 
-        GUILayout.Label("Force End Game", GUIStylePreset.TabSubtitle);
+        GUILayout.Label("Force End Game (Host Only)", GUIStylePreset.TabSubtitle);
         GUILayout.BeginHorizontal();
         if (GUILayout.Button("Impostors Win", GUIStylePreset.NormalButton)) MalumCheats.ForceEndGameCheat(true);
         if (GUILayout.Button("Crewmates Win", GUIStylePreset.NormalButton)) MalumCheats.ForceEndGameCheat(false);
@@ -71,12 +71,12 @@ public class HostOnlyTab : ITab
     {
         GUILayout.Label("Meetings", GUIStylePreset.TabSubtitle);
 
-        CheatToggles.skipMeeting = GUILayout.Toggle(CheatToggles.skipMeeting, " Skip Meeting");
+        CheatToggles.skipMeeting = GUILayout.Toggle(CheatToggles.skipMeeting, " Skip Meeting (Host Only)");
 
-        CheatToggles.voteImmune = GUILayout.Toggle(CheatToggles.voteImmune, " Vote Immune");
+        CheatToggles.voteImmune = GUILayout.Toggle(CheatToggles.voteImmune, " Vote Immune (Host Only)");
 
-        CheatToggles.ejectPlayer = GUILayout.Toggle(CheatToggles.ejectPlayer, " Eject Player");
+        CheatToggles.ejectPlayer = GUILayout.Toggle(CheatToggles.ejectPlayer, " Eject Player (Host Only)");
 
-        CheatToggles.infiniteMeetings = GUILayout.Toggle(CheatToggles.infiniteMeetings, " Infinite Meetings");
+        CheatToggles.infiniteMeetings = GUILayout.Toggle(CheatToggles.infiniteMeetings, " Infinite Meetings (Host Only)");
     }
 }

--- a/src/UI/Windows/Tabs/HostOnlyTab.cs
+++ b/src/UI/Windows/Tabs/HostOnlyTab.cs
@@ -16,10 +16,6 @@ public class HostOnlyTab : ITab
 
         GUILayout.Space(15);
 
-        DrawMurder();
-
-        GUILayout.Space(15);
-
         DrawGameState();
 
         GUILayout.EndVertical();
@@ -28,10 +24,6 @@ public class HostOnlyTab : ITab
 
         DrawMeetings();
 
-        GUILayout.Space(15);
-
-        DrawSmartKill();
-
         GUILayout.EndVertical();
 
         GUILayout.EndHorizontal();
@@ -39,17 +31,11 @@ public class HostOnlyTab : ITab
 
     private void DrawGeneral()
     {
-        CheatToggles.killVanished = GUILayout.Toggle(CheatToggles.killVanished, " Kill While Vanished");
-
-        CheatToggles.killAnyone = GUILayout.Toggle(CheatToggles.killAnyone, " Kill Anyone");
-
         CheatToggles.noKillCd = GUILayout.Toggle(CheatToggles.noKillCd, " No Kill Cooldown");
 
         CheatToggles.showProtectMenu = GUILayout.Toggle(CheatToggles.showProtectMenu, " Show Protect Menu");
 
-        CheatToggles.showForceTeleportMenu = GUILayout.Toggle(CheatToggles.showForceTeleportMenu, " Force Teleport");
-
-        CheatToggles.freezePlayer = GUILayout.Toggle(CheatToggles.freezePlayer, " Freeze Player");
+        CheatToggles.showForceTeleportMenu = GUILayout.Toggle(CheatToggles.showForceTeleportMenu, " Force Teleport Menu");
 
         CheatToggles.showKillCdOverlay = GUILayout.Toggle(CheatToggles.showKillCdOverlay, " Show Kill Cooldown on Players");
 
@@ -59,26 +45,11 @@ public class HostOnlyTab : ITab
 
         CheatToggles.antiBotKick = GUILayout.Toggle(CheatToggles.antiBotKick, " Auto-Kick Bots");
 
-        CheatToggles.autoKickVentImpostors = GUILayout.Toggle(CheatToggles.autoKickVentImpostors, " Kick Players Who Vent");
+        CheatToggles.autoKickVentImpostors = GUILayout.Toggle(CheatToggles.autoKickVentImpostors, " Disconnect Players Who Vent");
 
         // CheatToggles.forceRole = GUILayout.Toggle(CheatToggles.forceRole, " Force Role");
 
         // CheatToggles.noOptionsLimits = GUILayout.Toggle(CheatToggles.noOptionsLimits, " No Options Limits");
-    }
-
-    private void DrawMurder()
-    {
-        GUILayout.Label("Murder", GUIStylePreset.TabSubtitle);
-
-        CheatToggles.killPlayer = GUILayout.Toggle(CheatToggles.killPlayer, " Kill Player");
-
-        CheatToggles.telekillPlayer = GUILayout.Toggle(CheatToggles.telekillPlayer, " Telekill Player");
-
-        CheatToggles.killAllCrew = GUILayout.Toggle(CheatToggles.killAllCrew, " Kill All Crewmates");
-
-        CheatToggles.killAllImps = GUILayout.Toggle(CheatToggles.killAllImps, " Kill All Impostors");
-
-        CheatToggles.killAll = GUILayout.Toggle(CheatToggles.killAll, " Kill Everyone");
     }
 
     private void DrawGameState()
@@ -107,22 +78,5 @@ public class HostOnlyTab : ITab
         CheatToggles.ejectPlayer = GUILayout.Toggle(CheatToggles.ejectPlayer, " Eject Player");
 
         CheatToggles.infiniteMeetings = GUILayout.Toggle(CheatToggles.infiniteMeetings, " Infinite Meetings");
-    }
-
-    private void DrawSmartKill()
-    {
-        GUILayout.Label("Smart Kill", GUIStylePreset.TabSubtitle);
-
-        var (canExecute, statusText) = MalumCheats.SmartKillStatus();
-
-        var prevColor = GUI.contentColor;
-        GUI.contentColor = canExecute ? Color.green : new Color(1f, 0.4f, 0.4f);
-        GUILayout.Label(statusText);
-        GUI.contentColor = prevColor;
-
-        GUI.enabled = canExecute;
-        if (GUILayout.Button("Close Door + Kill + Vent", GUIStylePreset.NormalButton))
-            MalumCheats.SmartKillCombo();
-        GUI.enabled = true;
     }
 }

--- a/src/UI/Windows/Tabs/HostOnlyTab.cs
+++ b/src/UI/Windows/Tabs/HostOnlyTab.cs
@@ -43,6 +43,9 @@ public class HostOnlyTab : ITab
 
         CheatToggles.alwaysImpostor = GUILayout.Toggle(CheatToggles.alwaysImpostor, " Always Impostor (Host Only)");
 
+        if (Utils.isHost)
+            CheatToggles.assignImpostor = GUILayout.Toggle(CheatToggles.assignImpostor, " Assign Impostor (Host Only)");
+
         CheatToggles.antiBotKick = GUILayout.Toggle(CheatToggles.antiBotKick, " Auto-Kick Bots (Host Only)");
 
         CheatToggles.autoKickVentImpostors = GUILayout.Toggle(CheatToggles.autoKickVentImpostors, " Disconnect Players Who Vent (Host Only)");

--- a/src/UI/Windows/Tabs/HostOnlyTab.cs
+++ b/src/UI/Windows/Tabs/HostOnlyTab.cs
@@ -37,7 +37,7 @@ public class HostOnlyTab : ITab
 
         CheatToggles.showForceTeleportMenu = GUILayout.Toggle(CheatToggles.showForceTeleportMenu, " Force Teleport Menu");
 
-        CheatToggles.showKillCdOverlay = GUILayout.Toggle(CheatToggles.showKillCdOverlay, " Show Kill Cooldown on Players");
+        CheatToggles.showKillCdOverlay = GUILayout.Toggle(CheatToggles.showKillCdOverlay, " Show Impostor Kill Timer Above Players");
 
         CheatToggles.showMeetingHistory = GUILayout.Toggle(CheatToggles.showMeetingHistory, " Meeting History");
 

--- a/src/UI/Windows/Tabs/HostOnlyTab.cs
+++ b/src/UI/Windows/Tabs/HostOnlyTab.cs
@@ -28,6 +28,10 @@ public class HostOnlyTab : ITab
 
         DrawMeetings();
 
+        GUILayout.Space(15);
+
+        DrawSmartKill();
+
         GUILayout.EndVertical();
 
         GUILayout.EndHorizontal();
@@ -101,5 +105,22 @@ public class HostOnlyTab : ITab
         CheatToggles.ejectPlayer = GUILayout.Toggle(CheatToggles.ejectPlayer, " Eject Player");
 
         CheatToggles.infiniteMeetings = GUILayout.Toggle(CheatToggles.infiniteMeetings, " Infinite Meetings");
+    }
+
+    private void DrawSmartKill()
+    {
+        GUILayout.Label("Smart Kill", GUIStylePreset.TabSubtitle);
+
+        var (canExecute, statusText) = MalumCheats.SmartKillStatus();
+
+        var prevColor = GUI.contentColor;
+        GUI.contentColor = canExecute ? Color.green : new Color(1f, 0.4f, 0.4f);
+        GUILayout.Label(statusText);
+        GUI.contentColor = prevColor;
+
+        GUI.enabled = canExecute;
+        if (GUILayout.Button("Close Door + Kill + Vent", GUIStylePreset.NormalButton))
+            MalumCheats.SmartKillCombo();
+        GUI.enabled = true;
     }
 }

--- a/src/UI/Windows/Tabs/ImpostorTab.cs
+++ b/src/UI/Windows/Tabs/ImpostorTab.cs
@@ -1,0 +1,109 @@
+using UnityEngine;
+
+namespace MalumMenu;
+
+public class ImpostorTab : ITab
+{
+    public string name => "Impostor";
+
+    public void Draw()
+    {
+        GUILayout.BeginHorizontal();
+
+        GUILayout.BeginVertical(GUILayout.Width(MenuUI.windowWidth * 0.425f));
+
+        DrawKill();
+
+        GUILayout.Space(15);
+
+        DrawMassKill();
+
+        GUILayout.Space(15);
+
+        DrawSmartKill();
+
+        GUILayout.EndVertical();
+
+        GUILayout.BeginVertical();
+
+        DrawKillMods();
+
+        GUILayout.Space(15);
+
+        DrawShapeshifter();
+
+        GUILayout.Space(15);
+
+        DrawPhantom();
+
+        GUILayout.EndVertical();
+
+        GUILayout.EndHorizontal();
+    }
+
+    private void DrawKill()
+    {
+        GUILayout.Label("Kill", GUIStylePreset.TabSubtitle);
+
+        CheatToggles.killPlayer = GUILayout.Toggle(CheatToggles.killPlayer, " Kill Player");
+
+        CheatToggles.telekillPlayer = GUILayout.Toggle(CheatToggles.telekillPlayer, " Telekill Player");
+
+        CheatToggles.killAnyone = GUILayout.Toggle(CheatToggles.killAnyone, " Kill Anyone");
+
+        CheatToggles.killVanished = GUILayout.Toggle(CheatToggles.killVanished, " Kill While Vanished");
+    }
+
+    private void DrawMassKill()
+    {
+        GUILayout.Label("Mass Kill", GUIStylePreset.TabSubtitle);
+
+        CheatToggles.killAllCrew = GUILayout.Toggle(CheatToggles.killAllCrew, " Kill All Crewmates");
+
+        CheatToggles.killAllImps = GUILayout.Toggle(CheatToggles.killAllImps, " Kill All Impostors");
+
+        CheatToggles.killAll = GUILayout.Toggle(CheatToggles.killAll, " Kill Everyone");
+    }
+
+    private void DrawSmartKill()
+    {
+        GUILayout.Label("Smart Kill", GUIStylePreset.TabSubtitle);
+
+        var (canExecute, statusText) = MalumCheats.SmartKillStatus();
+
+        var prevColor = GUI.contentColor;
+        GUI.contentColor = canExecute ? Color.green : new Color(1f, 0.4f, 0.4f);
+        GUILayout.Label(statusText);
+        GUI.contentColor = prevColor;
+
+        GUI.enabled = canExecute;
+        if (GUILayout.Button("Close Door + Kill + Vent", GUIStylePreset.NormalButton))
+            MalumCheats.SmartKillCombo();
+        GUI.enabled = true;
+    }
+
+    private void DrawKillMods()
+    {
+        GUILayout.Label("Kill Mods", GUIStylePreset.TabSubtitle);
+
+        CheatToggles.killReach = GUILayout.Toggle(CheatToggles.killReach, " Infinite Kill Range");
+    }
+
+    private void DrawShapeshifter()
+    {
+        GUILayout.Label("Shapeshifter", GUIStylePreset.TabSubtitle);
+
+        CheatToggles.noShapeshiftAnim = GUILayout.Toggle(CheatToggles.noShapeshiftAnim, " No Shapeshift Animation");
+
+        CheatToggles.endlessSsDuration = GUILayout.Toggle(CheatToggles.endlessSsDuration, " Endless Shapeshift Duration");
+    }
+
+    private void DrawPhantom()
+    {
+        GUILayout.Label("Phantom / Viper", GUIStylePreset.TabSubtitle);
+
+        CheatToggles.endlessVanish = GUILayout.Toggle(CheatToggles.endlessVanish, " Endless Vanish");
+
+        CheatToggles.noVanishAnim = GUILayout.Toggle(CheatToggles.noVanishAnim, " No Vanish Animation");
+    }
+}

--- a/src/UI/Windows/Tabs/ModesTab.cs
+++ b/src/UI/Windows/Tabs/ModesTab.cs
@@ -22,5 +22,7 @@ public class ModesTab : ITab
         CheatToggles.stealthMode = GUILayout.Toggle(CheatToggles.stealthMode, " Stealth Mode");
 
         CheatToggles.panicMode = GUILayout.Toggle(CheatToggles.panicMode, " Panic Mode");
+
+        CheatToggles.streamerMode = GUILayout.Toggle(CheatToggles.streamerMode, " Streamer Mode (F12)");
     }
 }

--- a/src/UI/Windows/Tabs/MovementTab.cs
+++ b/src/UI/Windows/Tabs/MovementTab.cs
@@ -17,6 +17,10 @@ public class MovementTab : ITab
 
         DrawTeleport();
 
+        GUILayout.Space(15);
+
+        DrawExtras();
+
         GUILayout.EndVertical();
     }
 
@@ -47,8 +51,19 @@ public class MovementTab : ITab
     {
         GUILayout.Label("Teleport", GUIStylePreset.TabSubtitle);
 
-        CheatToggles.teleportCursor = GUILayout.Toggle(CheatToggles.teleportCursor, " to Cursor");
+        CheatToggles.teleportCursor = GUILayout.Toggle(CheatToggles.teleportCursor, " to Cursor (RMB)");
 
         CheatToggles.teleportPlayer = GUILayout.Toggle(CheatToggles.teleportPlayer, " to Player");
+
+        CheatToggles.blink = GUILayout.Toggle(CheatToggles.blink, " Blink to Cursor (MMB)");
+    }
+
+    private void DrawExtras()
+    {
+        GUILayout.Label("Extras", GUIStylePreset.TabSubtitle);
+
+        CheatToggles.visionBoost      = GUILayout.Toggle(CheatToggles.visionBoost,      " Vision Boost");
+
+        CheatToggles.showMeetingTimer = GUILayout.Toggle(CheatToggles.showMeetingTimer, " Meeting Timer");
     }
 }

--- a/src/UI/Windows/Tabs/MovementTab.cs
+++ b/src/UI/Windows/Tabs/MovementTab.cs
@@ -9,6 +9,7 @@ public class MovementTab : ITab
 
     public void Draw()
     {
+        GUILayout.BeginHorizontal();
         GUILayout.BeginVertical(GUILayout.Width(MenuUI.windowWidth * 0.425f));
 
         DrawGeneral();
@@ -22,6 +23,7 @@ public class MovementTab : ITab
         DrawExtras();
 
         GUILayout.EndVertical();
+        GUILayout.EndHorizontal();
     }
 
     private void DrawGeneral()

--- a/src/UI/Windows/Tabs/PassiveTab.cs
+++ b/src/UI/Windows/Tabs/PassiveTab.cs
@@ -8,6 +8,8 @@ public class PassiveTab : ITab
 
     public void Draw()
     {
+        GUILayout.BeginHorizontal();
+
         GUILayout.BeginVertical(GUILayout.Width(MenuUI.windowWidth * 0.425f));
 
         DrawGeneral();
@@ -17,6 +19,8 @@ public class PassiveTab : ITab
         DrawNameSpoof();
 
         GUILayout.EndVertical();
+
+        GUILayout.EndHorizontal();
     }
 
     private void DrawNameSpoof()

--- a/src/UI/Windows/Tabs/PassiveTab.cs
+++ b/src/UI/Windows/Tabs/PassiveTab.cs
@@ -12,7 +12,26 @@ public class PassiveTab : ITab
 
         DrawGeneral();
 
+        GUILayout.Space(15);
+
+        DrawNameSpoof();
+
         GUILayout.EndVertical();
+    }
+
+    private void DrawNameSpoof()
+    {
+        GUILayout.Label("Name Spoof", GUIStylePreset.TabSubtitle);
+        CheatToggles.spoofedName = GUILayout.TextField(CheatToggles.spoofedName, 20, GUILayout.Width(200f));
+        if (GUILayout.Button("Apply Name", GUIStylePreset.NormalButton))
+        {
+            try
+            {
+                if (!string.IsNullOrWhiteSpace(CheatToggles.spoofedName))
+                    PlayerControl.LocalPlayer.RpcSetName(CheatToggles.spoofedName);
+            }
+            catch { }
+        }
     }
 
     private void DrawGeneral()

--- a/src/UI/Windows/Tabs/PassiveTab.cs
+++ b/src/UI/Windows/Tabs/PassiveTab.cs
@@ -40,14 +40,14 @@ public class PassiveTab : ITab
 
     private void DrawGeneral()
     {
-        CheatToggles.freeCosmetics = GUILayout.Toggle(CheatToggles.freeCosmetics, " Free Cosmetics");
+        CheatToggles.freeCosmetics = GUILayout.Toggle(CheatToggles.freeCosmetics, " Unlock All Cosmetics Free");
 
-        CheatToggles.avoidPenalties = GUILayout.Toggle(CheatToggles.avoidPenalties, " Avoid Penalties");
+        CheatToggles.avoidPenalties = GUILayout.Toggle(CheatToggles.avoidPenalties, " Skip Vote/Ban Penalties");
 
-        CheatToggles.unlockFeatures = GUILayout.Toggle(CheatToggles.unlockFeatures, " Unlock Extra Features");
+        CheatToggles.unlockFeatures = GUILayout.Toggle(CheatToggles.unlockFeatures, " Unlock Hidden Game Features");
 
-        CheatToggles.copyLobbyCodeOnDisconnect = GUILayout.Toggle(CheatToggles.copyLobbyCodeOnDisconnect, " Copy Lobby Code on Disconnect");
+        CheatToggles.copyLobbyCodeOnDisconnect = GUILayout.Toggle(CheatToggles.copyLobbyCodeOnDisconnect, " Copy Lobby Code When Disconnected");
 
-        CheatToggles.spoofAprilFoolsDate = GUILayout.Toggle(CheatToggles.spoofAprilFoolsDate, " Spoof Date to April 1st");
+        CheatToggles.spoofAprilFoolsDate = GUILayout.Toggle(CheatToggles.spoofAprilFoolsDate, " Enable April Fools Mode");
     }
 }

--- a/src/UI/Windows/Tabs/PassiveTab.cs
+++ b/src/UI/Windows/Tabs/PassiveTab.cs
@@ -14,13 +14,28 @@ public class PassiveTab : ITab
 
         DrawGeneral();
 
-        GUILayout.Space(15);
+        GUILayout.EndVertical();
+
+        GUILayout.BeginVertical(GUILayout.Width(MenuUI.windowWidth * 0.425f));
 
         DrawNameSpoof();
 
         GUILayout.EndVertical();
 
         GUILayout.EndHorizontal();
+    }
+
+    private void DrawGeneral()
+    {
+        CheatToggles.freeCosmetics = GUILayout.Toggle(CheatToggles.freeCosmetics, " Unlock All Cosmetics Free");
+
+        CheatToggles.avoidPenalties = GUILayout.Toggle(CheatToggles.avoidPenalties, " Skip Vote/Ban Penalties");
+
+        CheatToggles.unlockFeatures = GUILayout.Toggle(CheatToggles.unlockFeatures, " Unlock Hidden Game Features");
+
+        CheatToggles.copyLobbyCodeOnDisconnect = GUILayout.Toggle(CheatToggles.copyLobbyCodeOnDisconnect, " Copy Lobby Code When Disconnected");
+
+        CheatToggles.spoofAprilFoolsDate = GUILayout.Toggle(CheatToggles.spoofAprilFoolsDate, " Enable April Fools Mode");
     }
 
     private void DrawNameSpoof()
@@ -36,18 +51,5 @@ public class PassiveTab : ITab
             }
             catch { }
         }
-    }
-
-    private void DrawGeneral()
-    {
-        CheatToggles.freeCosmetics = GUILayout.Toggle(CheatToggles.freeCosmetics, " Unlock All Cosmetics Free");
-
-        CheatToggles.avoidPenalties = GUILayout.Toggle(CheatToggles.avoidPenalties, " Skip Vote/Ban Penalties");
-
-        CheatToggles.unlockFeatures = GUILayout.Toggle(CheatToggles.unlockFeatures, " Unlock Hidden Game Features");
-
-        CheatToggles.copyLobbyCodeOnDisconnect = GUILayout.Toggle(CheatToggles.copyLobbyCodeOnDisconnect, " Copy Lobby Code When Disconnected");
-
-        CheatToggles.spoofAprilFoolsDate = GUILayout.Toggle(CheatToggles.spoofAprilFoolsDate, " Enable April Fools Mode");
     }
 }

--- a/src/UI/Windows/Tabs/RolesTab.cs
+++ b/src/UI/Windows/Tabs/RolesTab.cs
@@ -60,7 +60,7 @@ public class RolesTab : ITab
     {
         GUILayout.Label("Impostor", GUIStylePreset.TabSubtitle);
 
-        CheatToggles.killReach = GUILayout.Toggle(CheatToggles.killReach, " Kill Reach");
+        CheatToggles.killReach = GUILayout.Toggle(CheatToggles.killReach, " Infinite Kill Range");
 
         // CheatToggles.impostorTasks = GUILayout.Toggle(CheatToggles.impostorTasks, " Allow Tasks");
     }
@@ -69,11 +69,11 @@ public class RolesTab : ITab
     {
         GUILayout.Label("Shapeshifter", GUIStylePreset.TabSubtitle);
 
-        CheatToggles.noShapeshiftAnim = GUILayout.Toggle(CheatToggles.noShapeshiftAnim, " No Ss Animation");
+        CheatToggles.noShapeshiftAnim = GUILayout.Toggle(CheatToggles.noShapeshiftAnim, " No Shapeshift Animation");
 
-        CheatToggles.endlessSsDuration = GUILayout.Toggle(CheatToggles.endlessSsDuration, " Endless Ss Duration");
+        CheatToggles.endlessSsDuration = GUILayout.Toggle(CheatToggles.endlessSsDuration, " Endless Shapeshift Duration");
 
-        CheatToggles.fakeShapeshift = GUILayout.Toggle(CheatToggles.fakeShapeshift, " Fake Shapeshift");
+        CheatToggles.fakeShapeshift = GUILayout.Toggle(CheatToggles.fakeShapeshift, " Disguise as Another Player");
     }
 
     private void DrawCrewmate()
@@ -87,13 +87,13 @@ public class RolesTab : ITab
     {
         GUILayout.Label("Tracker", GUIStylePreset.TabSubtitle);
 
-        CheatToggles.endlessTracking = GUILayout.Toggle(CheatToggles.endlessTracking, " Endless Tracking");
+        CheatToggles.endlessTracking = GUILayout.Toggle(CheatToggles.endlessTracking, " Endless Tracker Duration");
 
-        CheatToggles.noTrackingDelay = GUILayout.Toggle(CheatToggles.noTrackingDelay, " No Track Delay");
+        CheatToggles.noTrackingDelay = GUILayout.Toggle(CheatToggles.noTrackingDelay, " No Tracker Delay");
 
-        CheatToggles.noTrackingCooldown = GUILayout.Toggle(CheatToggles.noTrackingCooldown, " No Track Cooldown");
+        CheatToggles.noTrackingCooldown = GUILayout.Toggle(CheatToggles.noTrackingCooldown, " No Tracker Cooldown");
 
-        CheatToggles.trackReach = GUILayout.Toggle(CheatToggles.trackReach, " Track Reach");
+        CheatToggles.trackReach = GUILayout.Toggle(CheatToggles.trackReach, " Infinite Track Range");
     }
 
     private void DrawEngineer()
@@ -118,6 +118,6 @@ public class RolesTab : ITab
     {
         GUILayout.Label("Detective", GUIStylePreset.TabSubtitle);
 
-        CheatToggles.interrogateReach = GUILayout.Toggle(CheatToggles.interrogateReach, " Interrogate Reach");
+        CheatToggles.interrogateReach = GUILayout.Toggle(CheatToggles.interrogateReach, " Infinite Interrogate Range");
     }
 }

--- a/src/UI/Windows/Tabs/RolesTab.cs
+++ b/src/UI/Windows/Tabs/RolesTab.cs
@@ -72,6 +72,8 @@ public class RolesTab : ITab
         CheatToggles.noShapeshiftAnim = GUILayout.Toggle(CheatToggles.noShapeshiftAnim, " No Ss Animation");
 
         CheatToggles.endlessSsDuration = GUILayout.Toggle(CheatToggles.endlessSsDuration, " Endless Ss Duration");
+
+        CheatToggles.fakeShapeshift = GUILayout.Toggle(CheatToggles.fakeShapeshift, " Fake Shapeshift");
     }
 
     private void DrawCrewmate()

--- a/src/UI/Windows/Tabs/RolesTab.cs
+++ b/src/UI/Windows/Tabs/RolesTab.cs
@@ -16,14 +16,6 @@ public class RolesTab : ITab
 
         GUILayout.Space(15);
 
-        DrawImpostor();
-
-        GUILayout.Space(15);
-
-        DrawShapeshifter();
-
-        GUILayout.Space(15);
-
         DrawCrewmate();
 
         GUILayout.Space(15);
@@ -54,26 +46,6 @@ public class RolesTab : ITab
         CheatToggles.setFakeRole = GUILayout.Toggle(CheatToggles.setFakeRole, " Set Fake Role");
 
         CheatToggles.setFakeAlive = GUILayout.Toggle(CheatToggles.setFakeAlive, " Set Fake Alive");
-    }
-
-    private void DrawImpostor()
-    {
-        GUILayout.Label("Impostor", GUIStylePreset.TabSubtitle);
-
-        CheatToggles.killReach = GUILayout.Toggle(CheatToggles.killReach, " Infinite Kill Range");
-
-        // CheatToggles.impostorTasks = GUILayout.Toggle(CheatToggles.impostorTasks, " Allow Tasks");
-    }
-
-    private void DrawShapeshifter()
-    {
-        GUILayout.Label("Shapeshifter", GUIStylePreset.TabSubtitle);
-
-        CheatToggles.noShapeshiftAnim = GUILayout.Toggle(CheatToggles.noShapeshiftAnim, " No Shapeshift Animation");
-
-        CheatToggles.endlessSsDuration = GUILayout.Toggle(CheatToggles.endlessSsDuration, " Endless Shapeshift Duration");
-
-        CheatToggles.fakeShapeshift = GUILayout.Toggle(CheatToggles.fakeShapeshift, " Disguise as Another Player");
     }
 
     private void DrawCrewmate()

--- a/src/UI/Windows/Tabs/ShipTab.cs
+++ b/src/UI/Windows/Tabs/ShipTab.cs
@@ -35,6 +35,8 @@ public class ShipTab : ITab
 
         // CheatToggles.reportBody = GUILayout.Toggle(CheatToggles.reportBody, " Report Body");
 
+        CheatToggles.autoReport  = GUILayout.Toggle(CheatToggles.autoReport,  " Auto Report Bodies");
+
         CheatToggles.callMeeting = GUILayout.Toggle(CheatToggles.callMeeting, " Call Meeting");
 
         CheatToggles.closeMeeting = GUILayout.Toggle(CheatToggles.closeMeeting, " Close Meeting");

--- a/src/UI/Windows/Tabs/ShipTab.cs
+++ b/src/UI/Windows/Tabs/ShipTab.cs
@@ -73,6 +73,8 @@ public class ShipTab : ITab
 
         CheatToggles.kickVents = GUILayout.Toggle(CheatToggles.kickVents, " Kick All From Vents");
 
+        CheatToggles.autoBootVents = GUILayout.Toggle(CheatToggles.autoBootVents, " Auto Boot Impostors From Vents");
+
         CheatToggles.walkInVents = GUILayout.Toggle(CheatToggles.walkInVents, " Walk In Vents");
     }
 }

--- a/src/UI/Windows/Tabs/TrollTab.cs
+++ b/src/UI/Windows/Tabs/TrollTab.cs
@@ -37,12 +37,12 @@ public class TrollTab : ITab
     {
         GUILayout.Label("Frame Players", GUIStylePreset.TabSubtitle);
 
-        CheatToggles.frameAsShapeshifter = GUILayout.Toggle(CheatToggles.frameAsShapeshifter, " Frame as Shapeshifter");
+        CheatToggles.frameAsShapeshifter = GUILayout.Toggle(CheatToggles.frameAsShapeshifter, " Frame as Shapeshifter (Host Only)");
         GUILayout.Label("<size=10>Pick victim → pick disguise target\nOthers see victim shapeshift (looks like hacking)</size>");
 
         GUILayout.Space(5);
 
-        CheatToggles.fakeVentOnPlayer = GUILayout.Toggle(CheatToggles.fakeVentOnPlayer, " Fake Vent on Player");
+        CheatToggles.fakeVentOnPlayer = GUILayout.Toggle(CheatToggles.fakeVentOnPlayer, " Fake Vent on Player (Host Only)");
         GUILayout.Label("<size=10>Others see the player enter a vent</size>");
     }
 

--- a/src/UI/Windows/Tabs/TrollTab.cs
+++ b/src/UI/Windows/Tabs/TrollTab.cs
@@ -68,5 +68,9 @@ public class TrollTab : ITab
 
         CheatToggles.freezePlayer = GUILayout.Toggle(CheatToggles.freezePlayer, " Freeze Player (Host Only)");
         GUILayout.Label("<size=10>Continuously snap a player back to one spot</size>");
+
+        GUILayout.Space(5);
+        CheatToggles.avengerMode = GUILayout.Toggle(CheatToggles.avengerMode, " Avenger Mode");
+        GUILayout.Label("<size=10>On kill: teleport to body, start overload on killer, report</size>");
     }
 }

--- a/src/UI/Windows/Tabs/TrollTab.cs
+++ b/src/UI/Windows/Tabs/TrollTab.cs
@@ -50,7 +50,7 @@ public class TrollTab : ITab
     {
         GUILayout.Label("Force Teleport", GUIStylePreset.TabSubtitle);
 
-        CheatToggles.teleportPlayerToPlayer = GUILayout.Toggle(CheatToggles.teleportPlayerToPlayer, " Teleport Player to Player");
+        CheatToggles.teleportPlayerToPlayer = GUILayout.Toggle(CheatToggles.teleportPlayerToPlayer, " Teleport Player to Player (Host Only)");
         GUILayout.Label("<size=10>Pick player A → pick player B\nMoves A to B's position</size>");
     }
 
@@ -66,7 +66,7 @@ public class TrollTab : ITab
     {
         GUILayout.Label("Control", GUIStylePreset.TabSubtitle);
 
-        CheatToggles.freezePlayer = GUILayout.Toggle(CheatToggles.freezePlayer, " Freeze Player");
+        CheatToggles.freezePlayer = GUILayout.Toggle(CheatToggles.freezePlayer, " Freeze Player (Host Only)");
         GUILayout.Label("<size=10>Continuously snap a player back to one spot</size>");
     }
 }

--- a/src/UI/Windows/Tabs/TrollTab.cs
+++ b/src/UI/Windows/Tabs/TrollTab.cs
@@ -1,0 +1,72 @@
+using UnityEngine;
+
+namespace MalumMenu;
+
+public class TrollTab : ITab
+{
+    public string name => "Troll";
+
+    public void Draw()
+    {
+        GUILayout.BeginHorizontal();
+
+        GUILayout.BeginVertical(GUILayout.Width(MenuUI.windowWidth * 0.425f));
+
+        DrawFrame();
+
+        GUILayout.Space(15);
+
+        DrawTeleport();
+
+        GUILayout.Space(15);
+
+        DrawDisguise();
+
+        GUILayout.EndVertical();
+
+        GUILayout.BeginVertical();
+
+        DrawFreeze();
+
+        GUILayout.EndVertical();
+
+        GUILayout.EndHorizontal();
+    }
+
+    private void DrawFrame()
+    {
+        GUILayout.Label("Frame Players", GUIStylePreset.TabSubtitle);
+
+        CheatToggles.frameAsShapeshifter = GUILayout.Toggle(CheatToggles.frameAsShapeshifter, " Frame as Shapeshifter");
+        GUILayout.Label("<size=10>Pick victim → pick disguise target\nOthers see victim shapeshift (looks like hacking)</size>");
+
+        GUILayout.Space(5);
+
+        CheatToggles.fakeVentOnPlayer = GUILayout.Toggle(CheatToggles.fakeVentOnPlayer, " Fake Vent on Player");
+        GUILayout.Label("<size=10>Others see the player enter a vent</size>");
+    }
+
+    private void DrawTeleport()
+    {
+        GUILayout.Label("Force Teleport", GUIStylePreset.TabSubtitle);
+
+        CheatToggles.teleportPlayerToPlayer = GUILayout.Toggle(CheatToggles.teleportPlayerToPlayer, " Teleport Player to Player");
+        GUILayout.Label("<size=10>Pick player A → pick player B\nMoves A to B's position</size>");
+    }
+
+    private void DrawDisguise()
+    {
+        GUILayout.Label("Disguise", GUIStylePreset.TabSubtitle);
+
+        CheatToggles.fakeShapeshift = GUILayout.Toggle(CheatToggles.fakeShapeshift, " Disguise as Another Player");
+        GUILayout.Label("<size=10>You appear to be someone else on others' screens</size>");
+    }
+
+    private void DrawFreeze()
+    {
+        GUILayout.Label("Control", GUIStylePreset.TabSubtitle);
+
+        CheatToggles.freezePlayer = GUILayout.Toggle(CheatToggles.freezePlayer, " Freeze Player");
+        GUILayout.Label("<size=10>Continuously snap a player back to one spot</size>");
+    }
+}

--- a/src/UI/Windows/TasksUI.cs
+++ b/src/UI/Windows/TasksUI.cs
@@ -27,7 +27,7 @@ public class TasksUI : MonoBehaviour
 
     private void OnGUI()
     {
-        if (!CheatToggles.showTasksMenu || !(MenuUI.isGUIActive || MalumMenu.menuKeepSubwindowsOpen.Value) || MalumMenu.isPanicked) return;
+        if (!CheatToggles.showTasksMenu || !(MenuUI.isGUIActive || MalumMenu.menuKeepSubwindowsOpen.Value) || MalumMenu.isPanicked || CheatToggles.streamerMode) return;
 
         _playerHeaderStyle ??= new GUIStyle(GUI.skin.button)
         {

--- a/src/Utilities/Utils.cs
+++ b/src/Utilities/Utils.cs
@@ -165,6 +165,23 @@ public static class Utils
         PlayerControl.LocalPlayer.NetTransform.RpcSnapTo(position);
     }
 
+    // Broadcasts a raw Shapeshift RPC from LocalPlayer into the target with animation,
+    // bypassing CmdCheckShapeshift so no shapeshifter role is required.
+    public static void SendFakeShapeshift(PlayerControl target)
+    {
+        foreach (var player in PlayerControl.AllPlayerControls)
+        {
+            var writer = AmongUsClient.Instance.StartRpcImmediately(
+                PlayerControl.LocalPlayer.NetId,
+                (byte)RpcCalls.Shapeshift,
+                SendOption.None,
+                AmongUsClient.Instance.GetClientIdFromCharacter(player));
+            writer.WriteNetObject(target);
+            writer.Write(true); // shouldAnimate
+            AmongUsClient.Instance.FinishRpcImmediately(writer);
+        }
+    }
+
     // Kills any player using RPC calls
     public static void MurderPlayer(PlayerControl target, MurderResultFlags result)
     {
@@ -235,14 +252,15 @@ public static class Utils
             lineRenderer = sourceObject.AddComponent<LineRenderer>();
         }
 
-        lineRenderer.SetVertexCount(2);
+        lineRenderer.positionCount = 2;
         lineRenderer.SetWidth(0.02F, 0.02F);
 
         // I just picked an already existing material from the game
         Material material = DestroyableSingleton<HatManager>.Instance.PlayerMaterial;
 
         lineRenderer.material = material;
-        lineRenderer.SetColors(color, color);
+        lineRenderer.startColor = color;
+        lineRenderer.endColor   = color;
 
         lineRenderer.SetPosition(0, sourceObject.transform.position);
         lineRenderer.SetPosition(1, targetObject.transform.position);
@@ -781,6 +799,11 @@ public static class Utils
         UnityEngine.Object.Destroy(MalumMenu.doorsUI);
         UnityEngine.Object.Destroy(MalumMenu.tasksUI);
         UnityEngine.Object.Destroy(MalumMenu.protectUI);
+        UnityEngine.Object.Destroy(MalumMenu.forceTeleportUI);
+        UnityEngine.Object.Destroy(MalumMenu.meetingHistoryUI);
+        UnityEngine.Object.Destroy(MalumMenu.playerNotesUI);
+        FootprintHandler.Clear();
+        BodyIntelHandler.Clear();
         // UnityEngine.Object.Destroy(MalumMenu.rolesUI);
 
         UnityEngine.Object.Destroy(MalumMenu.keybindListener);

--- a/src/Utilities/Utils.cs
+++ b/src/Utilities/Utils.cs
@@ -193,6 +193,43 @@ public static class Utils
         }
     }
 
+    // Sends Shapeshift RPC appearing to come FROM victim — other clients see victim do shapeshift animation
+    public static void FrameAsShapeshifter(PlayerControl victim, PlayerControl shapeshiftTarget)
+    {
+        var host = AmongUsClient.Instance.GetHost();
+        foreach (var player in PlayerControl.AllPlayerControls)
+        {
+            if (host?.Character != null && player == host.Character) continue;
+            if (player == victim) continue;
+            var writer = AmongUsClient.Instance.StartRpcImmediately(
+                victim.NetId,
+                (byte)RpcCalls.Shapeshift,
+                SendOption.None,
+                AmongUsClient.Instance.GetClientIdFromCharacter(player));
+            writer.WriteNetObject(shapeshiftTarget);
+            writer.Write(true);
+            AmongUsClient.Instance.FinishRpcImmediately(writer);
+        }
+    }
+
+    // Sends EnterVent RPC appearing to come FROM victim — other clients see victim enter a vent
+    public static void FakeVentOnPlayer(PlayerControl victim, int ventId)
+    {
+        var host = AmongUsClient.Instance.GetHost();
+        foreach (var player in PlayerControl.AllPlayerControls)
+        {
+            if (host?.Character != null && player == host.Character) continue;
+            if (player == victim) continue;
+            var writer = AmongUsClient.Instance.StartRpcImmediately(
+                victim.MyPhysics.NetId,
+                (byte)RpcCalls.EnterVent,
+                SendOption.None,
+                AmongUsClient.Instance.GetClientIdFromCharacter(player));
+            writer.Write(ventId);
+            AmongUsClient.Instance.FinishRpcImmediately(writer);
+        }
+    }
+
     // Kills any player using RPC calls
     public static void MurderPlayer(PlayerControl target, MurderResultFlags result)
     {

--- a/src/Utilities/Utils.cs
+++ b/src/Utilities/Utils.cs
@@ -194,40 +194,43 @@ public static class Utils
     }
 
     // Sends Shapeshift RPC appearing to come FROM victim — other clients see victim do shapeshift animation
+    // Requires host: non-host clients sending RPCs with another player's NetId get kicked by anticheat
     public static void FrameAsShapeshifter(PlayerControl victim, PlayerControl shapeshiftTarget)
     {
-        var host = AmongUsClient.Instance.GetHost();
-        foreach (var player in PlayerControl.AllPlayerControls)
+        if (!isHost)
         {
-            if (host?.Character != null && player == host.Character) continue;
-            if (player == victim) continue;
-            var writer = AmongUsClient.Instance.StartRpcImmediately(
-                victim.NetId,
-                (byte)RpcCalls.Shapeshift,
-                SendOption.None,
-                AmongUsClient.Instance.GetClientIdFromCharacter(player));
-            writer.WriteNetObject(shapeshiftTarget);
-            writer.Write(true);
-            AmongUsClient.Instance.FinishRpcImmediately(writer);
+            HudManager.Instance?.Notifier?.AddDisconnectMessage("Frame as Shapeshifter requires host");
+            return;
         }
+
+        // As host we have server authority — broadcast with targetClientId=-1 so all clients receive it
+        var writer = AmongUsClient.Instance.StartRpcImmediately(
+            victim.NetId,
+            (byte)RpcCalls.Shapeshift,
+            SendOption.None,
+            -1);
+        writer.WriteNetObject(shapeshiftTarget);
+        writer.Write(true);
+        AmongUsClient.Instance.FinishRpcImmediately(writer);
     }
 
     // Sends EnterVent RPC appearing to come FROM victim — other clients see victim enter a vent
+    // Requires host: same anticheat reason as FrameAsShapeshifter
     public static void FakeVentOnPlayer(PlayerControl victim, int ventId)
     {
-        var host = AmongUsClient.Instance.GetHost();
-        foreach (var player in PlayerControl.AllPlayerControls)
+        if (!isHost)
         {
-            if (host?.Character != null && player == host.Character) continue;
-            if (player == victim) continue;
-            var writer = AmongUsClient.Instance.StartRpcImmediately(
-                victim.MyPhysics.NetId,
-                (byte)RpcCalls.EnterVent,
-                SendOption.None,
-                AmongUsClient.Instance.GetClientIdFromCharacter(player));
-            writer.Write(ventId);
-            AmongUsClient.Instance.FinishRpcImmediately(writer);
+            HudManager.Instance?.Notifier?.AddDisconnectMessage("Fake Vent on Player requires host");
+            return;
         }
+
+        var writer = AmongUsClient.Instance.StartRpcImmediately(
+            victim.MyPhysics.NetId,
+            (byte)RpcCalls.EnterVent,
+            SendOption.None,
+            -1);
+        writer.Write(ventId);
+        AmongUsClient.Instance.FinishRpcImmediately(writer);
     }
 
     // Kills any player using RPC calls

--- a/src/Utilities/Utils.cs
+++ b/src/Utilities/Utils.cs
@@ -128,7 +128,7 @@ public static class Utils
     // Gets RoleBehaviour from a RoleType
     public static RoleBehaviour GetBehaviourByRoleType(RoleTypes roleType)
     {
-        return RoleManager.Instance.AllRoles.ToArray().First(r => r.Role == roleType);
+        return RoleManager.Instance.AllRoles.ToArray().FirstOrDefault(r => r.Role == roleType);
     }
 
     // Gets RoleBehaviour from a TeamType
@@ -165,12 +165,23 @@ public static class Utils
         PlayerControl.LocalPlayer.NetTransform.RpcSnapTo(position);
     }
 
+    // Coroutine to enter a vent after a brief delay (lets position sync first)
+    public static System.Collections.IEnumerator DelayedEnterVent(int ventId, float delay = 0.15f)
+    {
+        yield return new WaitForSeconds(delay);
+        try { PlayerControl.LocalPlayer.MyPhysics.RpcEnterVent(ventId); } catch { }
+    }
+
     // Broadcasts a raw Shapeshift RPC from LocalPlayer into the target with animation,
     // bypassing CmdCheckShapeshift so no shapeshifter role is required.
     public static void SendFakeShapeshift(PlayerControl target)
     {
+        var host = AmongUsClient.Instance.GetHost();
         foreach (var player in PlayerControl.AllPlayerControls)
         {
+            // Skip the host — host validates Shapeshift RPCs and will kick non-shapeshifters
+            if (!isHost && host?.Character != null && player == host.Character) continue;
+
             var writer = AmongUsClient.Instance.StartRpcImmediately(
                 PlayerControl.LocalPlayer.NetId,
                 (byte)RpcCalls.Shapeshift,
@@ -411,7 +422,7 @@ public static class Utils
 
         outputList = outputList.OrderBy(target => GetDistanceBetween(source, target)).ToList();
 
-        return outputList.Count <= 0 ? null : outputList;
+        return outputList;
     }
 
     // Returns current map ID if available
@@ -661,7 +672,8 @@ public static class Utils
     // Found here: https://github.com/NuclearPowered/Reactor/blob/6eb0bf19c30733b78532dada41db068b2b247742/Reactor/Networking/Patches/HttpPatches.cs
     public static void ShowPopup(string text)
     {
-        var popup = UnityEngine.Object.Instantiate(DiscordManager.Instance.discordPopup, Camera.main!.transform);
+        if (Camera.main == null) return;
+        var popup = UnityEngine.Object.Instantiate(DiscordManager.Instance.discordPopup, Camera.main.transform);
 
         var background = popup.transform.Find("Background").GetComponent<SpriteRenderer>();
         var size = background.size;


### PR DESCRIPTION
## Summary

This PR adds **33 new features** and several bug fixes across ESP, tracers, host-only tools, console logging, movement, roles, chat, troll, and passive categories. All changes are on top of the existing MalumMenu base.

---

## New Features

### Movement
- **Blink to Cursor** — snap-teleport to cursor position with middle mouse button

### ESP
- **Vision Boost** — massively increase vision range, ignoring light modifiers
- **Player Notes** — attach private notes to any player, shown on their nametag in-game

### Tracers
- **Vent Paths** — lines connecting all vents on the current map
- **Footprints** — fading colored footprints showing where each player has walked
- **Player Trail** — fading line drawn behind your own movement
- **Kill Range Indicator** — circle showing your current kill range

### Roles
- **Fake Shapeshift** — visually shapeshift into any player without being Shapeshifter (any role, non-host)
- **Force Role** *(Host only)* — assign any role to any player mid-game
- **Kill Cooldown Overlay** *(Host only)* — shows each impostor's kill cooldown on their nametag
- **Assign Impostor** *(Host only)* — PPM cheat: instantly set any player's role to Impostor via `RoleManager.SetRole`

### Ship
- **Auto Report Bodies** — automatically reports dead bodies when you walk near them
- **Auto-Open Doors On Use** — opens doors automatically on interaction
- **Force Teleport** *(Host only)* — teleport any player to a specific room or your current position
- **Freeze Player** *(Host only)* — lock a player in place, preventing movement
- **Infinite Meetings** *(Host only)* — removes the emergency meeting call limit

### Vents
- **Auto-Kick Vent Impostors** *(Host only)* — automatically kicks impostors from vents

### Console (entirely new section)
- **Show Console** — floating in-game console showing real-time cheat logs
- **Log Deaths** — logs every player death as it happens
- **Log Shapeshifts** — logs every shapeshift event
- **Log Vents** — logs every vent entry/exit (shows role of venter)
- **Kill Sound Alert** — plays an alert sound + logs when someone is killed
- **Sabotage Alert** — plays an alert sound + logs when a sabotage activates
- **Body Intel Logger** — logs who died, where, who was nearby, and who walked past the body
- **Chat Logger** — saves all chat to `BepInEx/config/MalumChat.txt`
- **Meeting History** — sub-window showing every vote from all previous meetings this game
- **Meeting Timer** — live countdown displayed during meetings

### Troll (new tab)
- **Avenger Mode** — when killed: teleports to body, starts overload on killer, auto-reports, auto-sends killer ID in meeting chat, shows HUD overlay with victim/killer/room + killer's post-kill action
- **Frame as Shapeshifter** *(Host only)* — fakes a shapeshift animation on a target player
- **Fake Vent on Player** *(Host only)* — makes a player appear to enter a vent to others
- **Teleport Player to Player** *(Host only)* — moves one player to another player's position

### Chat
- **Mod Chat** — private floating chat window only visible to other MalumMenu users; messages tagged with invisible Unicode prefix, intercepted in `ChatController.AddChat`, suppressed from regular game chat
- **Anti-Bot Kick** *(Host only, now in Passive)* — auto-kicks suspected bots (>4 messages/1.5s)

### Passive
- **Name Spoof** — set a custom display name visible to all players
- **Copy Lobby Code on Disconnect** — copies lobby code to clipboard on disconnect
- **Spoof Date to April 1st** — tricks the game into thinking it's April Fools' Day

### Modes
- **Streamer Mode** *(F12)* — hides menu UI and censors lobby code as `XXXXXX`

---

## Bug Fixes

- **fix: noClip and freezePlayer not reset on game exit** — both turn off on scene transition back to lobby
- **fix: SpectatePPM null crash on scene transition** — null check added in `PlayerPhysics.LateUpdate` patch
- **fix: chat Enter key blocked by IsCharAllowed patch** — Enter now correctly submits chat
- **fix: passive tab layout, added (Host Only) labels everywhere**
- **fix: freeze and teleport-to-player now require host to avoid anticheat kick**
- **fix: vent log shows impostor/crew role correctly, autoBootVents decoupled from logVents**
- **fix: frame as shapeshifter and fake vent now require host**

---

## New Files

| File | Purpose |
|------|---------|
| `src/Cheats/AvengerHandler.cs` | Avenger mode logic: kill detection, overload, auto-report, chat message |
| `src/Cheats/BodyIntelHandler.cs` | Body intel tracking: deaths, nearby players, passers-by |
| `src/Cheats/FootprintHandler.cs` | Footprints, player trail, kill range indicator rendering |
| `src/Cheats/ForceTeleportHandler.cs` | Room coordinate maps for all maps, teleport execution |
| `src/Patches/InfiniteMeetingsPatches.cs` | Restores emergency meeting count to 99 after each call |
| `src/Patches/LobbyCodeCensorPatches.cs` | Censors lobby code as `XXXXXX` in streamer mode |
| `src/UI/Windows/ForceTeleportUI.cs` | Floating window for force teleport player/room selection |
| `src/UI/Windows/MeetingHistoryUI.cs` | Floating window showing per-round vote history |
| `src/UI/Windows/ModChatUI.cs` | Floating mod-only chat window with input, send, and clear |
| `src/UI/Windows/PlayerNotesUI.cs` | Floating window for editing per-player private notes |
| `src/UI/Windows/Tabs/ImpostorTab.cs` | Reorganized impostor tab with Smart Kill Combo button |
| `src/UI/Windows/Tabs/TrollTab.cs` | New Troll tab grouping host-only griefing features |
| `src/Utilities/ModChatManager.cs` | Backend for mod chat: prefix tagging, message buffer, send/receive |