### PR TITLE
Add Phantom Cheats No Animation & Endless Duration

### DIFF
--- a/src/Cheats/MalumCheats.cs
+++ b/src/Cheats/MalumCheats.cs
@@ -148,6 +148,18 @@ public static class MalumCheats
         }
     }
 
+    public static void HandlePhantomCheats(PhantomRole phantomRole)
+    {
+        if (CheatToggles.endlessPhantomDuration)
+        {
+            phantomRole.durationSecondsRemaining = float.MaxValue;
+        }
+        else if (phantomRole.durationSecondsRemaining > GameManager.Instance.LogicOptions.GetRoleFloat(FloatOptionNames.PhantomDuration))
+        {
+            phantomRole.durationSecondsRemaining = GameManager.Instance.LogicOptions.GetRoleFloat(FloatOptionNames.PhantomDuration);
+        }
+    }
+
     public static void HandleScientistCheats(ScientistRole scientistRole)
     {
         if (CheatToggles.noVitalsCooldown)

--- a/src/Patches/PlayerControlPatches.cs
+++ b/src/Patches/PlayerControlPatches.cs
@@ -109,6 +109,7 @@ public static class PlayerControl_CmdCheckShapeshift
     }
 }
 
+
 [HarmonyPatch(typeof(PlayerControl), nameof(PlayerControl.CmdCheckRevertShapeshift))]
 public static class PlayerControl_CmdCheckRevertShapeshift
 {

--- a/src/Patches/RoleBehaviourPatches.cs
+++ b/src/Patches/RoleBehaviourPatches.cs
@@ -55,6 +55,21 @@ public static class TrackerRole_FixedUpdate
     }
 }
 
+[HarmonyPatch(typeof(PhantomRole), nameof(PhantomRole.FixedUpdate))]
+public static class PhantomRole_FixedUpdate
+{
+    public static void Postfix(PhantomRole __instance)
+    {
+        try
+        {
+            if(__instance.Player.AmOwner)
+            {
+                MalumCheats.HandlePhantomCheats(__instance);
+            }
+        } catch { }
+    }
+}
+
 [HarmonyPatch(typeof(PhantomRole), nameof(PhantomRole.IsValidTarget))]
 public static class PhantomRole_IsValidTarget
 {
@@ -65,6 +80,73 @@ public static class PhantomRole_IsValidTarget
         {
             __result = Utils.IsValidTarget(target);
         }
+    }
+}
+
+[HarmonyPatch(typeof(PhantomRole), nameof(PhantomRole.MakePlayerVisible))]
+public static class PhantomRole_MakePlayerVisible
+{
+    public static void Prefix(ref bool shouldAnimate)
+    {
+        if (shouldAnimate && CheatToggles.noPhantomAnim)
+        {
+            shouldAnimate = false;
+        }
+    }
+}
+
+[HarmonyPatch(typeof(PlayerControl), "SetRoleInvisibility")]
+public static class PlayerControl_SetRoleInvisibility
+{
+    public static void Prefix(ref bool shouldAnimate)
+    {
+        if (shouldAnimate && CheatToggles.noPhantomAnim)
+        {
+            shouldAnimate = false;
+        }
+    }
+}
+
+[HarmonyPatch(typeof(PhantomRole), nameof(PhantomRole.SetFading))]
+public static class PhantomRole_SetFading
+{
+    public static void Postfix(PhantomRole __instance, bool isFading)
+    {
+        if (CheatToggles.noPhantomAnim)
+        {
+            if (isFading)
+            {
+                // Force state to fully vanished immediately
+                __instance.fading = false;
+                __instance.isInvisible = true;
+                __instance.SetInvisible(true);
+            }
+            else
+            {
+                // Force state to fully visible immediately
+                __instance.fading = false;
+                __instance.isInvisible = false;
+                __instance.SetInvisible(false);
+            }
+        }
+    }
+}
+
+[HarmonyPatch(typeof(PhantomRole), nameof(PhantomRole.PlayPhantomVanishSound))]
+public static class PhantomRole_PlayPhantomVanishSound
+{
+    public static bool Prefix()
+    {
+        return !CheatToggles.noPhantomAnim;
+    }
+}
+
+[HarmonyPatch(typeof(PhantomRole), nameof(PhantomRole.PlayPhantomAppearSound))]
+public static class PhantomRole_PlayPhantomAppearSound
+{
+    public static bool Prefix()
+    {
+        return !CheatToggles.noPhantomAnim;
     }
 }
 

--- a/src/UI/Elements/CheatToggles.cs
+++ b/src/UI/Elements/CheatToggles.cs
@@ -24,6 +24,7 @@ public struct CheatToggles
     public static bool killReach;
     public static bool killAnyone;
     public static bool endlessSsDuration;
+    public static bool endlessPhantomDuration;
     public static bool endlessBattery;
     public static bool endlessTracking;
     public static bool noTrackingCooldown;
@@ -36,6 +37,7 @@ public struct CheatToggles
     public static bool endlessVanish;
     public static bool killVanished;
     public static bool noVanishAnim;
+    public static bool noPhantomAnim;
     public static bool noShapeshiftAnim;
 
     // ESP

--- a/src/UI/Windows/Tabs/RolesTab.cs
+++ b/src/UI/Windows/Tabs/RolesTab.cs
@@ -24,6 +24,10 @@ public class RolesTab : ITab
 
         GUILayout.Space(15);
 
+        DrawPhantom();
+
+        GUILayout.Space(15);
+
         DrawCrewmate();
 
         GUILayout.Space(15);
@@ -72,6 +76,15 @@ public class RolesTab : ITab
         CheatToggles.noShapeshiftAnim = GUILayout.Toggle(CheatToggles.noShapeshiftAnim, " No Ss Animation");
 
         CheatToggles.endlessSsDuration = GUILayout.Toggle(CheatToggles.endlessSsDuration, " Endless Ss Duration");
+    }
+
+    private void DrawPhantom()
+    {
+        GUILayout.Label("Phantom", GUIStylePreset.TabSubtitle);
+
+        CheatToggles.noPhantomAnim = GUILayout.Toggle(CheatToggles.noPhantomAnim, " No Phantom Animation");
+
+        CheatToggles.endlessPhantomDuration = GUILayout.Toggle(CheatToggles.endlessPhantomDuration, " Endless Phantom Duration");
     }
 
     private void DrawCrewmate()


### PR DESCRIPTION
Adds two new cheats for the Phantom role in the Roles category: an endless duration toggle and a no animation cheat. The no-animation cheat skips the animation & sound effects for the Phantom.

#564
https://discord.com/channels/1181598406112710726/1192870718489243768/threads/1504202290993692852
https://discord.com/channels/1181598406112710726/1192870718489243768/threads/1311025762660519980
https://discord.com/channels/1181598406112710726/1192870718489243768/threads/1497929179893858385