### PR TITLE
fix: prevent menu clicks passing through to game UI

### DIFF
--- a/src/Patches/ShapeshifterMinigamePatches.cs
+++ b/src/Patches/ShapeshifterMinigamePatches.cs
@@ -31,6 +31,12 @@ public static class ShapeshifterMinigame_Begin
 
             shapeshifterPanel.SetPlayer(i, playerData, (Il2CppSystem.Action) (() =>
             {
+                // Ignore click if it landed over the Malum menu window - IMGUI uses
+                // top-left origin so flip Y before comparing against the window rect
+                var mouse = Input.mousePosition;
+                var guiMouse = new Vector2(mouse.x, Screen.height - mouse.y);
+                if (MenuUI.isGUIActive && MenuUI.windowRect.Contains(guiMouse)) return;
+
                 PlayerPickMenu.targetPlayerData = playerData; // Save targeted player
 
                 PlayerPickMenu.customAction.Invoke(); // Custom action set by openPlayerPickMenu

--- a/src/UI/Windows/MenuUI.cs
+++ b/src/UI/Windows/MenuUI.cs
@@ -9,6 +9,7 @@ public class MenuUI : MonoBehaviour
     public static int windowHeight = 550;
     public static int windowWidth = 700;
     private Rect _windowRect;
+    public static Rect windowRect;
 
     public static bool isGUIActive = false;
     private List<ITab> _tabs = new();
@@ -190,6 +191,11 @@ public class MenuUI : MonoBehaviour
         UIHelpers.ApplyUIColor();
 
         _windowRect = GUI.Window((int)WindowId.MenuUI, _windowRect, (GUI.WindowFunction)WindowFunction, "MalumMenu v" + MalumMenu.malumVersion);
+        windowRect = _windowRect;
+
+        // Block mouse clicks from passing through to game/PPM when over menu window
+        if (_windowRect.Contains(Event.current.mousePosition) && Event.current.type == EventType.MouseDown)
+            Event.current.Use();
     }
 
     public void WindowFunction(int windowID)


### PR DESCRIPTION
Two-layer fix for mouse clicks landing on the MalumMenu window
accidentally triggering game UI elements (PPM panels, etc.).

- MenuUI.OnGUI: consume MouseDown events that land on the window rect
- ShapeshifterMinigamePatches: guard the Il2Cpp panel action lambda
  against clicks that overlap the menu window