### PR TITLE
feat: Host-Only Per-Player Role Assignment

### DIFF
--- a/src/Cheats/MalumPPMCheats.cs
+++ b/src/Cheats/MalumPPMCheats.cs
@@ -16,7 +16,6 @@ public static class MalumPPMCheats
     private static bool _ejectPlayerActive;
     private static bool _setFakeRoleActive;
     private static bool _setFakeAliveActive;
-    private static bool _forceRoleActive;
     private static RoleTypes? _oldRole = null;
 
     public static void ReportBodyPPM()
@@ -401,55 +400,7 @@ public static class MalumPPMCheats
         }
     }
 
-    public static void ForceRolePPM()
-    {
-        if (CheatToggles.forceRole)
-        {
-            if (!_forceRoleActive)
-            {
-                if (PlayerPickMenu.playerpickMenu != null)
-                {
-                    PlayerPickMenu.playerpickMenu.Close();
-                    CheatToggles.DisablePPMCheats("forceRole");
-                }
 
-                List<NetworkedPlayerInfo> playerDataList = new List<NetworkedPlayerInfo>();
-
-                playerDataList.Add(PlayerPickMenu.CustomPPMChoice("Shapeshifter", OutfitPreset.Shapeshifter, Utils.GetBehaviourByRoleType(RoleTypes.Shapeshifter)));
-                playerDataList.Add(PlayerPickMenu.CustomPPMChoice("Phantom", OutfitPreset.Phantom, Utils.GetBehaviourByRoleType(RoleTypes.Phantom)));
-                playerDataList.Add(PlayerPickMenu.CustomPPMChoice("Viper", OutfitPreset.Viper, Utils.GetBehaviourByRoleType(RoleTypes.Viper)));
-                playerDataList.Add(PlayerPickMenu.CustomPPMChoice("Impostor", OutfitPreset.Impostor, Utils.GetBehaviourByRoleType(RoleTypes.Impostor)));
-                playerDataList.Add(PlayerPickMenu.CustomPPMChoice("Tracker", OutfitPreset.Tracker, Utils.GetBehaviourByRoleType(RoleTypes.Tracker)));
-                playerDataList.Add(PlayerPickMenu.CustomPPMChoice("Noisemaker", OutfitPreset.Noisemaker, Utils.GetBehaviourByRoleType(RoleTypes.Noisemaker)));
-                playerDataList.Add(PlayerPickMenu.CustomPPMChoice("Engineer", OutfitPreset.Engineer, Utils.GetBehaviourByRoleType(RoleTypes.Engineer)));
-                playerDataList.Add(PlayerPickMenu.CustomPPMChoice("Scientist", OutfitPreset.Scientist, Utils.GetBehaviourByRoleType(RoleTypes.Scientist)));
-                playerDataList.Add(PlayerPickMenu.CustomPPMChoice("Detective", OutfitPreset.Detective, Utils.GetBehaviourByRoleType(RoleTypes.Detective)));
-                playerDataList.Add(PlayerPickMenu.CustomPPMChoice("Crewmate", OutfitPreset.Crewmate, Utils.GetBehaviourByRoleType(RoleTypes.Crewmate)));
-
-                // Player pick menu made for forcing a role onto another player
-                PlayerPickMenu.OpenPlayerPickMenu(playerDataList, (Action)(() =>
-                {
-                    CheatToggles.forcedRole = PlayerPickMenu.targetPlayerData.Role.Role;
-                }));
-
-                _forceRoleActive = true;
-            }
-
-            // Deactivate cheat if menu is closed
-            if (PlayerPickMenu.playerpickMenu == null)
-            {
-                CheatToggles.forceRole = false;
-            }
-
-        }
-        else
-        {
-            if (_forceRoleActive)
-            {
-                _forceRoleActive = false;
-            }
-        }
-    }
 
     public static void SpectatePPM()
     {

--- a/src/MalumMenu.cs
+++ b/src/MalumMenu.cs
@@ -1,4 +1,4 @@
-﻿using System.IO;
+using System.IO;
 using BepInEx;
 using BepInEx.Unity.IL2CPP;
 using UnityEngine.SceneManagement;
@@ -191,7 +191,7 @@ public partial class MalumMenu : BasePlugin
         doorsUI = AddComponent<DoorsUI>();
         tasksUI = AddComponent<TasksUI>();
         protectUI = AddComponent<ProtectUI>();
-        // rolesUI = AddComponent<RolesUI>();
+        rolesUI = AddComponent<RolesUI>();
 
         // Components
         keybindListener = AddComponent<KeybindListener>();

--- a/src/Patches/OtherPatches.cs
+++ b/src/Patches/OtherPatches.cs
@@ -337,33 +337,35 @@ public static class MushroomDoorSabotageMinigame_Begin
 [HarmonyPatch(typeof(IntroCutscene), "CoBegin")]
 public static class IntroCutscene_CoBegin
 {
-    // Prefix patch of IntroCutscene.CoBegin to force the LocalPlayer's role to a specified role
+    // Prefix patch of IntroCutscene.CoBegin to force assigned roles onto designated players
     public static void Prefix()
     {
-        if (!Utils.isHost || !CheatToggles.forcedRole.HasValue) return;
+        if (!Utils.isHost || CheatToggles.forcedRoles.Count == 0) return;
 
-        var forcedRole = CheatToggles.forcedRole.Value;
-
-        // If LocalPlayer already has the forced role, do nothing
-        if (PlayerControl.LocalPlayer.Data.RoleType == forcedRole)
+        foreach (var kvp in CheatToggles.forcedRoles)
         {
-            return;
-        }
+            byte playerId = kvp.Key;
+            RoleTypes targetRole = kvp.Value;
 
-        // Find a player with the forced role to swap roles with
-        PlayerControl roleSwapTarget = null;
-        foreach (var player in PlayerControl.AllPlayerControls)
-        {
-            if (player.Data.RoleType != forcedRole) continue;
-            roleSwapTarget = player;
-            break;
-        }
+            // Find the player by their ID
+            PlayerControl targetPlayer = null;
+            foreach (var player in PlayerControl.AllPlayerControls)
+            {
+                if (player.PlayerId == playerId)
+                {
+                    targetPlayer = player;
+                    break;
+                }
+            }
 
-        DestroyableSingleton<RoleManager>.Instance.SetRole(PlayerControl.LocalPlayer, forcedRole);
+            // Skip if player not found or disconnected
+            if (targetPlayer == null || targetPlayer.Data == null || targetPlayer.Data.Disconnected) continue;
 
-        if (roleSwapTarget != null)
-        {
-            DestroyableSingleton<RoleManager>.Instance.SetRole(roleSwapTarget, PlayerControl.LocalPlayer.Data.RoleType);
+            // Skip if player already has the desired role
+            if (targetPlayer.Data.RoleType == targetRole) continue;
+
+            // Assign the forced role
+            DestroyableSingleton<RoleManager>.Instance.SetRole(targetPlayer, targetRole);
         }
     }
 }

--- a/src/UI/Elements/CheatToggles.cs
+++ b/src/UI/Elements/CheatToggles.cs
@@ -141,8 +141,7 @@ public struct CheatToggles
 
     // Host-Only
     public static bool voteImmune;
-    public static bool forceRole;
-    public static RoleTypes? forcedRole;
+    public static Dictionary<byte, RoleTypes> forcedRoles = new();
     public static bool showRolesMenu;
     public static bool skipMeeting;
     public static bool forceStartGame;
@@ -203,13 +202,12 @@ public struct CheatToggles
         spectate = variableToKeep == "spectate" && spectate;
         setFakeRole = variableToKeep == "setFakeRole" && setFakeRole;
         setFakeAlive = variableToKeep == "setFakeAlive" && setFakeAlive;
-        forceRole = variableToKeep == "forceRole" && forceRole;
         teleportPlayer = variableToKeep == "teleportPlayer" && teleportPlayer;
     }
 
     public static bool ShouldPPMClose()
     {
-        return !setFakeRole && !setFakeAlive && !forceRole && !ejectPlayer && !reportBody && !telekillPlayer && !killPlayer && !spectate && !teleportPlayer;
+        return !setFakeRole && !setFakeAlive && !ejectPlayer && !reportBody && !telekillPlayer && !killPlayer && !spectate && !teleportPlayer;
     }
 
     // Disables all cheat toggles by setting all to false using the cached ToggleFields

--- a/src/UI/Windows/RolesUI.cs
+++ b/src/UI/Windows/RolesUI.cs
@@ -1,14 +1,30 @@
 using UnityEngine;
+using AmongUs.GameOptions;
 
 namespace MalumMenu;
 
 public class RolesUI : MonoBehaviour
 {
-    public static int windowHeight = 100;
-    public static int windowWidth = 450;
+    public static int windowHeight = 380;
+    public static int windowWidth = 560;
     private Rect _windowRect;
 
     private Vector2 _scrollPosition = Vector2.zero;
+
+    // All assignable roles in display order
+    private static readonly RoleTypes[] AllRoles = new[]
+    {
+        RoleTypes.Crewmate,
+        RoleTypes.Engineer,
+        RoleTypes.Scientist,
+        RoleTypes.Tracker,
+        RoleTypes.Noisemaker,
+        RoleTypes.Detective,
+        RoleTypes.Impostor,
+        RoleTypes.Shapeshifter,
+        RoleTypes.Phantom,
+        RoleTypes.Viper
+    };
 
     private void Start()
     {
@@ -38,31 +54,183 @@ public class RolesUI : MonoBehaviour
 
         foreach (var player in PlayerControl.AllPlayerControls)
         {
-            if (!player.Data || !player.Data.Role || string.IsNullOrEmpty(player.Data.PlayerName) || player != PlayerControl.LocalPlayer) continue;
+            if (!player.Data || !player.Data.Role || string.IsNullOrEmpty(player.Data.PlayerName)) continue;
+
+            byte playerId = player.PlayerId;
 
             GUILayout.BeginHorizontal();
 
-            GUILayout.Label($"<color=#{ColorUtility.ToHtmlStringRGB(player.Data.Color)}>{player.Data.PlayerName}</color>", GUILayout.Width(140f));
-            GUILayout.BeginHorizontal();
-            GUILayout.Label($"{CheatToggles.forcedRole}");
-            GUILayout.FlexibleSpace();
+            // Player name colored by their Among Us color
+            GUILayout.Label(
+                $"<color=#{ColorUtility.ToHtmlStringRGB(player.Data.Color)}>{player.Data.PlayerName}</color>",
+                GUILayout.Width(140f)
+            );
 
-            if (GUILayout.Button("Reset", GUILayout.Width(80f)))
+            // ◄ button to cycle role backward
+            if (GUILayout.Button("◄", GUILayout.Width(30f)))
             {
-                CheatToggles.forcedRole = null;
-            }
-            if (GUILayout.Button("Assign", GUILayout.Width(80f)))
-            {
-                CheatToggles.forceRole = true;
+                CycleRole(playerId, -1);
             }
 
-            GUILayout.EndHorizontal();
+            // Display current role assignment (or "None") with team color
+            string roleLabel;
+            if (CheatToggles.forcedRoles.TryGetValue(playerId, out var assignedRole))
+            {
+                string roleColor = IsImpostorTeam(assignedRole) ? "FF1919" : "8CFFFF";
+                roleLabel = $"<color=#{roleColor}>{GetRoleDisplayName(assignedRole)}</color>";
+            }
+            else
+            {
+                roleLabel = "<color=#888888>None</color>";
+            }
+
+            GUILayout.Label(roleLabel, new GUIStyle(GUI.skin.label)
+            {
+                alignment = TextAnchor.MiddleCenter,
+                fontSize = 14,
+                richText = true
+            }, GUILayout.Width(130f));
+
+            // ► button to cycle role forward
+            if (GUILayout.Button("►", GUILayout.Width(30f)))
+            {
+                CycleRole(playerId, 1);
+            }
+
+            // Reset button for this player
+            if (GUILayout.Button("Reset", GUIStylePreset.NormalButton, GUILayout.Width(60f)))
+            {
+                CheatToggles.forcedRoles.Remove(playerId);
+            }
+
             GUILayout.EndHorizontal();
         }
 
         GUILayout.EndScrollView();
+
+        // Separator
+        GUILayout.Box("", GUIStylePreset.DarkSeparator, GUILayout.Height(1f), GUILayout.ExpandWidth(true));
+
+        // Bottom controls row
+        GUILayout.BeginHorizontal();
+
+        if (GUILayout.Button("Reset All", GUILayout.Width(90f)))
+        {
+            CheatToggles.forcedRoles.Clear();
+        }
+
+        GUILayout.FlexibleSpace();
+
+        // Status summary
+        int totalAssigned = CheatToggles.forcedRoles.Count;
+        int impCount = 0;
+        int crewCount = 0;
+
+        foreach (var kvp in CheatToggles.forcedRoles)
+        {
+            if (IsImpostorTeam(kvp.Value))
+                impCount++;
+            else
+                crewCount++;
+        }
+
+        int totalPlayers = 0;
+        foreach (var player in PlayerControl.AllPlayerControls)
+        {
+            if (player.Data != null && !string.IsNullOrEmpty(player.Data.PlayerName))
+                totalPlayers++;
+        }
+
+        GUILayout.Label(
+            $"Assigned: {totalAssigned}/{totalPlayers}  |  <color=#FF1919>Imps: {impCount}</color>  |  <color=#8CFFFF>Crew: {crewCount}</color>",
+            new GUIStyle(GUI.skin.label) { richText = true, fontSize = 13 }
+        );
+
+        GUILayout.EndHorizontal();
+
+        GUILayout.Label("Roles will be assigned on next game start", new GUIStyle(GUI.skin.label)
+        {
+            fontStyle = FontStyle.Italic,
+            fontSize = 12,
+            alignment = TextAnchor.MiddleCenter
+        });
+
         GUILayout.EndVertical();
-        GUILayout.Label("Roles will be assigned on next game start");
+
         GUI.DragWindow();
+    }
+
+    /// <summary>
+    /// Cycles the assigned role for a player by the given direction (+1 forward, -1 backward).
+    /// If the player has no assignment, cycling forward starts at the first role,
+    /// cycling backward starts at the last role.
+    /// Cycling past the ends wraps to "None" (unassigned).
+    /// </summary>
+    private static void CycleRole(byte playerId, int direction)
+    {
+        if (CheatToggles.forcedRoles.TryGetValue(playerId, out var currentRole))
+        {
+            int currentIndex = System.Array.IndexOf(AllRoles, currentRole);
+
+            if (currentIndex == -1)
+            {
+                // Unknown role in the dictionary — reset to first
+                CheatToggles.forcedRoles[playerId] = AllRoles[0];
+                return;
+            }
+
+            int newIndex = currentIndex + direction;
+
+            if (newIndex < 0 || newIndex >= AllRoles.Length)
+            {
+                // Wrap to "None"
+                CheatToggles.forcedRoles.Remove(playerId);
+            }
+            else
+            {
+                CheatToggles.forcedRoles[playerId] = AllRoles[newIndex];
+            }
+        }
+        else
+        {
+            // Currently "None" — enter the list
+            if (direction > 0)
+            {
+                CheatToggles.forcedRoles[playerId] = AllRoles[0];
+            }
+            else
+            {
+                CheatToggles.forcedRoles[playerId] = AllRoles[AllRoles.Length - 1];
+            }
+        }
+    }
+
+    /// <summary>
+    /// Returns a human-readable name for the role type.
+    /// </summary>
+    private static string GetRoleDisplayName(RoleTypes role)
+    {
+        return role switch
+        {
+            RoleTypes.Crewmate => "Crewmate",
+            RoleTypes.Engineer => "Engineer",
+            RoleTypes.Scientist => "Scientist",
+            RoleTypes.Tracker => "Tracker",
+            RoleTypes.Noisemaker => "Noisemaker",
+            RoleTypes.Detective => "Detective",
+            RoleTypes.Impostor => "Impostor",
+            RoleTypes.Shapeshifter => "Shapeshifter",
+            RoleTypes.Phantom => "Phantom",
+            RoleTypes.Viper => "Viper",
+            _ => role.ToString()
+        };
+    }
+
+    /// <summary>
+    /// Returns true if the role belongs to the impostor team.
+    /// </summary>
+    private static bool IsImpostorTeam(RoleTypes role)
+    {
+        return role is RoleTypes.Impostor or RoleTypes.Shapeshifter or RoleTypes.Phantom or RoleTypes.Viper;
     }
 }

--- a/src/UI/Windows/Tabs/HostOnlyTab.cs
+++ b/src/UI/Windows/Tabs/HostOnlyTab.cs
@@ -43,7 +43,7 @@ public class HostOnlyTab : ITab
 
         CheatToggles.showProtectMenu = GUILayout.Toggle(CheatToggles.showProtectMenu, " Show Protect Menu");
 
-        // CheatToggles.forceRole = GUILayout.Toggle(CheatToggles.forceRole, " Force Role");
+        CheatToggles.showRolesMenu = GUILayout.Toggle(CheatToggles.showRolesMenu, " Assign Roles");
 
         // CheatToggles.noOptionsLimits = GUILayout.Toggle(CheatToggles.noOptionsLimits, " No Options Limits");
     }

--- a/src/Utilities/Utils.cs
+++ b/src/Utilities/Utils.cs
@@ -781,7 +781,7 @@ public static class Utils
         UnityEngine.Object.Destroy(MalumMenu.doorsUI);
         UnityEngine.Object.Destroy(MalumMenu.tasksUI);
         UnityEngine.Object.Destroy(MalumMenu.protectUI);
-        // UnityEngine.Object.Destroy(MalumMenu.rolesUI);
+        UnityEngine.Object.Destroy(MalumMenu.rolesUI);
 
         UnityEngine.Object.Destroy(MalumMenu.keybindListener);
 


### PR DESCRIPTION
## Summary

Implements a complete host-only role assignment system that lets the host pre-assign specific roles to **any player** in the lobby before the game starts. Roles are applied at game start via the `IntroCutscene.CoBegin` patch.

## Features

- **New Assign Roles sub-window** — Accessible via the Host-Only tab toggle
- **Per-player role cycling** — Use arrow buttons to cycle through all 10 vanilla roles for each player
- **All vanilla roles supported**: Crewmate, Engineer, Scientist, Tracker, Noisemaker, Detective, Impostor, Shapeshifter, Phantom, Viper
- **Team-colored role labels** — Red for impostor team, cyan for crewmate team
- **Reset / Reset All** — Clear individual or all assignments
- **Status bar** — Shows `Assigned: X/Y | Imps: N | Crew: M`

## Changes

| File | Change |
|------|--------|
| `CheatToggles.cs` | Replaced single `forcedRole` field with per-player `Dictionary<byte, RoleTypes> forcedRoles` |
| `RolesUI.cs` | Complete rewrite with per-player role cycling UI |
| `HostOnlyTab.cs` | Added 'Assign Roles' toggle (replaces commented-out 'Force Role') |
| `OtherPatches.cs` | Rewritten `IntroCutscene_CoBegin` to apply assignments for all designated players |
| `MalumMenu.cs` | Uncommented `rolesUI` component registration |
| `Utils.cs` | Uncommented `rolesUI` destruction in Panic cleanup |
| `MalumPPMCheats.cs` | Removed obsolete `ForceRolePPM()` method |

## How to Use

1. Open MalumMenu (DELETE key) → **Host-Only** tab
2. Enable **Assign Roles** — opens the role assignment window
3. Use **◄ / ►** buttons to cycle roles for each player
4. Start the game — roles are forced during the intro cutscene

## Build

Builds successfully with 0 warnings and 0 errors against MalumMenu v3.1.1 / Among Us 2026.3.31.