### PR TITLE
Disable the Overload tab and UI

### DIFF
--- a/src/MalumMenu.cs
+++ b/src/MalumMenu.cs
@@ -122,50 +122,50 @@ public partial class MalumMenu : BasePlugin
                                 true,
                                 "When enabled, it will stop Among Us from collecting analytics of your games and sending them to Innersloth using Unity Analytics");
 
-        adaptMaxStrength = Config.Bind("MalumMenu.Overload",
-                                "AdaptMaxStrength",
-                                18000,
-                                new ConfigDescription(
-                                    "Maximum total number of RPCs sent during one overload cycle in AutoAdapt mode. Automatically divided between targets and reduced based on ping. IMPORTANT: Only goes from 1 to 100K RPCs",
-                                    new AcceptableValueRange<int>(1, 100000)
-                                ));
+        // adaptMaxStrength = Config.Bind("MalumMenu.Overload",
+        //                         "AdaptMaxStrength",
+        //                         18000,
+        //                         new ConfigDescription(
+        //                             "Maximum total number of RPCs sent during one overload cycle in AutoAdapt mode. Automatically divided between targets and reduced based on ping. IMPORTANT: Only goes from 1 to 100K RPCs",
+        //                             new AcceptableValueRange<int>(1, 100000)
+        //                         ));
 
-        adaptMaxCooldown = Config.Bind("MalumMenu.Overload",
-                                "AdaptMaxCooldown",
-                                1f,
-                                new ConfigDescription(
-                                    "Maximum time (in seconds) for one full overload cycle to complete in AutoAdapt mode. Automatically distributed across targets (more targets = shorter delay per target). IMPORTANT: Only goes from 0s to 10s",
-                                    new AcceptableValueRange<float>(0f, 10f)
-                                ));
+        // adaptMaxCooldown = Config.Bind("MalumMenu.Overload",
+        //                         "AdaptMaxCooldown",
+        //                         1f,
+        //                         new ConfigDescription(
+        //                             "Maximum time (in seconds) for one full overload cycle to complete in AutoAdapt mode. Automatically distributed across targets (more targets = shorter delay per target). IMPORTANT: Only goes from 0s to 10s",
+        //                             new AcceptableValueRange<float>(0f, 10f)
+        //                         ));
 
-        attackLogDelay = Config.Bind("MalumMenu.Overload",
-                                "AttackLogDelay",
-                                2f,
-                                "Minimum time (in seconds) between attack logs in normal (non-verbose) mode");
+        // attackLogDelay = Config.Bind("MalumMenu.Overload",
+        //                         "AttackLogDelay",
+        //                         2f,
+        //                         "Minimum time (in seconds) between attack logs in normal (non-verbose) mode");
 
-        defaultStrength = Config.Bind("MalumMenu.Overload",
-                                "DefaultStrength",
-                                18000,
-                                new ConfigDescription(
-                                    "Default number of malformed RPCs sent to each target during an overload cycle. Overridden if AutoAdapt mode is enabled. IMPORTANT: Only goes from 1 to 100K RPCs",
-                                    new AcceptableValueRange<int>(1, 100000)
-                                ));
+        // defaultStrength = Config.Bind("MalumMenu.Overload",
+        //                         "DefaultStrength",
+        //                         18000,
+        //                         new ConfigDescription(
+        //                             "Default number of malformed RPCs sent to each target during an overload cycle. Overridden if AutoAdapt mode is enabled. IMPORTANT: Only goes from 1 to 100K RPCs",
+        //                             new AcceptableValueRange<int>(1, 100000)
+        //                         ));
 
-        defaultCooldown = Config.Bind("MalumMenu.Overload",
-                                "DefaultCooldown",
-                                1f,
-                                new ConfigDescription(
-                                    "Default cooldown (in seconds) between each target during an overload cycle. Overridden if AutoAdapt mode is enabled. IMPORTANT: Only goes from 0s to 10s",
-                                    new AcceptableValueRange<float>(0f, 10f)
-                                ));
+        // defaultCooldown = Config.Bind("MalumMenu.Overload",
+        //                         "DefaultCooldown",
+        //                         1f,
+        //                         new ConfigDescription(
+        //                             "Default cooldown (in seconds) between each target during an overload cycle. Overridden if AutoAdapt mode is enabled. IMPORTANT: Only goes from 0s to 10s",
+        //                             new AcceptableValueRange<float>(0f, 10f)
+        //                         ));
 
-        killSwitchLvl = Config.Bind("MalumMenu.Overload",
-                                "DefaultKillSwitchLevel",
-                                1,
-                                new ConfigDescription(
-                                    "Default level used by kill switch. Each level adds 500 ms to the max allowed ping before overload stops. Helps avoid lagging / disconnects. IMPORTANT: Only goes from level 1 (500 ms) to 6 (3000 ms)",
-                                    new AcceptableValueRange<int>(1, 6)
-                                ));
+        // killSwitchLvl = Config.Bind("MalumMenu.Overload",
+        //                         "DefaultKillSwitchLevel",
+        //                         1,
+        //                         new ConfigDescription(
+        //                             "Default level used by kill switch. Each level adds 500 ms to the max allowed ping before overload stops. Helps avoid lagging / disconnects. IMPORTANT: Only goes from level 1 (500 ms) to 6 (3000 ms)",
+        //                             new AcceptableValueRange<int>(1, 6)
+        //                         ));
 
         // Enabled by default
         CheatToggles.unlockFeatures = true;
@@ -187,10 +187,10 @@ public partial class MalumMenu : BasePlugin
         // UI
         menuUI = AddComponent<MenuUI>();
         consoleUI = AddComponent<ConsoleUI>();
-        overloadUI = AddComponent<OverloadUI>();
         doorsUI = AddComponent<DoorsUI>();
         tasksUI = AddComponent<TasksUI>();
         protectUI = AddComponent<ProtectUI>();
+        // overloadUI = AddComponent<OverloadUI>();
         // rolesUI = AddComponent<RolesUI>();
 
         // Components

--- a/src/Patches/PlayerPhysicsPatches.cs
+++ b/src/Patches/PlayerPhysicsPatches.cs
@@ -34,10 +34,10 @@ public static class PlayerPhysics_LateUpdate
 
         // This check ensures there is only one run per frame
         // so that OverloadHandler._timer progression remains accurate
-        if (__instance.AmOwner)
-        {
-            OverloadHandler.Run();
-        }
+        // if (__instance.AmOwner)
+        // {
+        //     OverloadHandler.Run();
+        // }
 
         TracersHandler.DrawPlayerTracer(__instance);
 

--- a/src/UI/Windows/MenuUI.cs
+++ b/src/UI/Windows/MenuUI.cs
@@ -24,12 +24,12 @@ public class MenuUI : MonoBehaviour
         _tabs.Add(new ShipTab());
         _tabs.Add(new ChatTab());
         _tabs.Add(new AnimationsTab());
-        _tabs.Add(new OverloadTab());
         _tabs.Add(new ConsoleTab());
         _tabs.Add(new HostOnlyTab());
         _tabs.Add(new PassiveTab());
         _tabs.Add(new ModesTab());
         _tabs.Add(new ConfigTab());
+        // _tabs.Add(new OverloadTab());
 
         // Instantiate 2D area of MenuUI
         _windowRect = new(

--- a/src/Utilities/Utils.cs
+++ b/src/Utilities/Utils.cs
@@ -777,11 +777,11 @@ public static class Utils
         UnityEngine.Object.Destroy(MalumMenu.menuUI);
 
         UnityEngine.Object.Destroy(MalumMenu.consoleUI);
-        UnityEngine.Object.Destroy(MalumMenu.overloadUI);
         UnityEngine.Object.Destroy(MalumMenu.doorsUI);
         UnityEngine.Object.Destroy(MalumMenu.tasksUI);
         UnityEngine.Object.Destroy(MalumMenu.protectUI);
         // UnityEngine.Object.Destroy(MalumMenu.rolesUI);
+        // UnityEngine.Object.Destroy(MalumMenu.overloadUI);
 
         UnityEngine.Object.Destroy(MalumMenu.keybindListener);
 


### PR DESCRIPTION
- **Fix**: Disable the Overload tab and UI
  - Disables the feature for users because it currently causes kicks, without removing it from the codebase.
  - Done to keep the feature easy to re-enable while I continue testing fixes.