### PR TITLE
Fix v18 API breakage and add a Hide Console toggle

### DIFF
--- a/src/Cheats/MalumCheats.cs
+++ b/src/Cheats/MalumCheats.cs
@@ -26,7 +26,7 @@ public static class MalumCheats
             PlayerControl.LocalPlayer.SetKillTimer(GameManager.Instance.LogicOptions.GetKillCooldown());
             ShipStatus.Instance.EmergencyCooldown = GameManager.Instance.LogicOptions.GetEmergencyCooldown();
             Camera.main.GetComponent<FollowerCamera>().Locked = false;
-            DestroyableSingleton<HudManager>.Instance.SetMapButtonEnabled(true);
+            DestroyableSingleton<HudManager>.Instance.SetMapAndInfoButtonsEnabled(true);
             DestroyableSingleton<HudManager>.Instance.SetHudActive(true);
             ControllerManager.Instance.CloseAndResetAll();
 
@@ -46,7 +46,7 @@ public static class MalumCheats
 
         if (Utils.isMeeting)
         {
-            MeetingHud.Instance.RpcVotingComplete(new Il2CppStructArray<MeetingHud.VoterState>(0L), null, true);
+            MeetingHud.Instance.RpcVotingComplete(new Il2CppStructArray<MeetingHud.VoterState>(0L), null, true, false, 0);
         }
 
         CheatToggles.skipMeeting = false;

--- a/src/Cheats/MalumESP.cs
+++ b/src/Cheats/MalumESP.cs
@@ -84,7 +84,7 @@ public static class MalumESP
             foreach (var playerState in meetingHud.playerStates)
             {
                 // Fetch the NetworkedPlayerInfo of each playerState
-                var data = GameData.Instance.GetPlayerById(playerState.TargetPlayerId);
+                var data = GameData.Instance.GetPlayerById(playerState.PlayerId);
 
                 if (data.IsNull() || data.Disconnected || data.Outfits[PlayerOutfitType.Default].IsNull()) continue;
 

--- a/src/Cheats/MalumPPMCheats.cs
+++ b/src/Cheats/MalumPPMCheats.cs
@@ -90,7 +90,7 @@ public static class MalumPPMCheats
                 PlayerPickMenu.OpenPlayerPickMenu(playerInfo, (Action)(() =>
                 {
                     NetworkedPlayerInfo playerToEject = PlayerPickMenu.targetPlayerData;
-                    MeetingHud.Instance.RpcVotingComplete(new Il2CppStructArray<MeetingHud.VoterState>(0L), playerToEject, false);
+                    MeetingHud.Instance.RpcVotingComplete(new Il2CppStructArray<MeetingHud.VoterState>(0L), playerToEject, false, false, 0);
                 }));
 
                 _ejectPlayerActive = true;

--- a/src/MalumMenu.cs
+++ b/src/MalumMenu.cs
@@ -228,4 +228,24 @@ public partial class MalumMenu : BasePlugin
             }
         }));
     }
+
+    // Shows or hides the BepInEx console window based on the hideBepInExConsole cheat toggle
+    public static void ApplyConsoleVisibility()
+    {
+        try
+        {
+            if (!CheatToggles.hideBepInExConsole && !ConsoleManager.ConsoleActive)
+            {
+                ConsoleManager.CreateConsole();
+            }
+            else if (CheatToggles.hideBepInExConsole && ConsoleManager.ConsoleActive)
+            {
+                ConsoleManager.DetachConsole();
+            }
+        }
+        catch (Exception ex)
+        {
+            Log.LogWarning($"Could not apply console visibility: {ex.Message}");
+        }
+    }
 }

--- a/src/MalumMenu.cs
+++ b/src/MalumMenu.cs
@@ -31,7 +31,7 @@ public partial class MalumMenu : BasePlugin
     public static KeybindListener keybindListener;
 
     public static string malumVersion = "3.2.0";
-    public static List<string> supportedAU = new List<string> { "2026.6.5", "2026.3.31" };
+    public static List<string> supportedAU = new List<string> { "2026.8.18", "2026.6.5", "2026.3.31" };
     public static bool isPanicked = false;
     public static bool inStealthMode = false;
 

--- a/src/Patches/MeetingHudPatches.cs
+++ b/src/Patches/MeetingHudPatches.cs
@@ -13,23 +13,23 @@ public static class MeetingHud_Update
     // Prefix patch of MeetingHud.Update to constantly bloop new vote icons for each new vote being cast during the meeting
     public static void Prefix(MeetingHud __instance)
     {
-        if (__instance.state < MeetingHud.VoteStates.Results)
+        if (__instance.state < MeetingHud.MeetingStates.Results)
         {
             foreach (var playerVoteArea in __instance.playerStates)
             {
                 if (!playerVoteArea) continue;
 
-                var playerData = GameData.Instance.GetPlayerById(playerVoteArea.TargetPlayerId);
+                var playerData = GameData.Instance.GetPlayerById(playerVoteArea.PlayerId);
 
-                if (playerData != null && !playerData.Disconnected && playerVoteArea.VotedFor != PlayerVoteArea.HasNotVoted && playerVoteArea.VotedFor != PlayerVoteArea.MissedVote && playerVoteArea.VotedFor != PlayerVoteArea.DeadVote && !votedPlayers.Contains(playerVoteArea.TargetPlayerId))
+                if (playerData != null && !playerData.Disconnected && playerVoteArea.VotedForId != PlayerVoteArea.HasNotVoted && playerVoteArea.VotedForId != PlayerVoteArea.MissedVote && playerVoteArea.VotedForId != PlayerVoteArea.DeadVote && !votedPlayers.Contains(playerVoteArea.PlayerId))
                 {
-                    votedPlayers.Add(playerVoteArea.TargetPlayerId);
+                    votedPlayers.Add(playerVoteArea.PlayerId);
 
-                    if (playerVoteArea.VotedFor != PlayerVoteArea.SkippedVote)
+                    if (playerVoteArea.VotedForId != PlayerVoteArea.SkippedVote)
                     {
                         foreach (var votedForArea in __instance.playerStates)
                         {
-                            if (votedForArea.TargetPlayerId == playerVoteArea.VotedFor)
+                            if (votedForArea.PlayerId == playerVoteArea.VotedForId)
                             {
                                 __instance.BloopAVoteIcon(playerData, 0, votedForArea.transform);
                                 break;
@@ -139,12 +139,13 @@ public static class MeetingHud_CheckForEndVoting
             var playerState = __instance.playerStates[index];
             states[index] = new MeetingHud.VoterState
             {
-                VoterId = playerState.TargetPlayerId,
-                VotedForId = playerState.VotedFor
+                VoterId = playerState.PlayerId,
+                VotedForId = playerState.VotedForId
             };
         }
 
-        __instance.RpcVotingComplete(states, exiled, tie);
+        // Judge vote-overrules are not replayed here, so wasOverruled is false and overruleNonce is 0
+        __instance.RpcVotingComplete(states, exiled, tie, false, 0);
 
         return false;
     }

--- a/src/UI/Elements/CheatToggles.cs
+++ b/src/UI/Elements/CheatToggles.cs
@@ -170,6 +170,7 @@ public struct CheatToggles
     public static bool rgbMode;
     public static bool stealthMode;
     public static bool panicMode;
+    public static bool hideBepInExConsole;
 
     // Config
     public static bool reloadConfig;

--- a/src/UI/Windows/MenuUI.cs
+++ b/src/UI/Windows/MenuUI.cs
@@ -81,6 +81,8 @@ public class MenuUI : MonoBehaviour
 
         if (CheatToggles.panicMode) Utils.Panic();
 
+        MalumMenu.ApplyConsoleVisibility();
+
         var stamp = ModManager.Instance.ModStamp;
         if (stamp) stamp.enabled = !(MalumMenu.inStealthMode || MalumMenu.isPanicked);
 

--- a/src/UI/Windows/Tabs/ModesTab.cs
+++ b/src/UI/Windows/Tabs/ModesTab.cs
@@ -22,5 +22,7 @@ public class ModesTab : ITab
         CheatToggles.stealthMode = GUILayout.Toggle(CheatToggles.stealthMode, " Stealth Mode");
 
         CheatToggles.panicMode = GUILayout.Toggle(CheatToggles.panicMode, " Panic Mode");
+
+        CheatToggles.hideBepInExConsole = GUILayout.Toggle(CheatToggles.hideBepInExConsole, " Hide Console");
     }
 }

--- a/src/Utilities/Utils.cs
+++ b/src/Utilities/Utils.cs
@@ -32,8 +32,8 @@ public static class Utils
     public static bool isHost => AmongUsClient.Instance && AmongUsClient.Instance.AmHost;
     public static bool isInGame => AmongUsClient.Instance && AmongUsClient.Instance.GameState == InnerNetClient.GameStates.Started && isPlayer;
     public static bool isMeeting => MeetingHud.Instance;
-    public static bool isMeetingVoting => isMeeting && MeetingHud.Instance.state is MeetingHud.VoteStates.Voted or MeetingHud.VoteStates.NotVoted;
-    public static bool isMeetingProceeding => isMeeting && MeetingHud.Instance.state is MeetingHud.VoteStates.Proceeding;
+    public static bool isMeetingVoting => isMeeting && MeetingHud.Instance.state is MeetingHud.MeetingStates.Voted or MeetingHud.MeetingStates.NotVoted;
+    public static bool isMeetingProceeding => isMeeting && MeetingHud.Instance.state is MeetingHud.MeetingStates.Proceeding;
     public static bool isExiling => ExileController.Instance && !(isAirshipMap && SpawnInMinigame.Instance.isActiveAndEnabled);
     public static bool isAnySabotageActive => ShipStatus.Instance && SabotageSystem.AnyActive;
     public static bool isNormalGame => GameOptionsManager.Instance.CurrentGameOptions.GameMode == GameModes.Normal;


### PR DESCRIPTION
Fixes the v18 API breakage so this branch compiles again, and adds an optional toggle for the BepInEx console window.

### Why

`6efa9df` bumped `AmongUs.GameLibs.Steam` to `2026.8.18`, but the code still referenced members that v18 removed or renamed, so this branch currently fails with **40 compile errors**. This makes it build.

### API changes handled

| Old (17.4) | New (18) |
|---|---|
| `MeetingHud.VoteStates` | `MeetingHud.MeetingStates` (same members and order) |
| `PlayerVoteArea.TargetPlayerId` | `PlayerId` |
| `PlayerVoteArea.VotedFor` | `VotedForId` |
| `MeetingHud.RpcVotingComplete(states, exiled, tie)` | `+ bool wasOverruled, ushort overruleNonce` |
| `HudManager.SetMapButtonEnabled` | `SetMapAndInfoButtonsEnabled` |

`PlayerVoteArea.PlayerId`/`VotedForId` are now `InnerNet.PlayerId`, which has implicit conversions to and from `byte`, so the surrounding byte-based code is unaffected. `MeetingHud.VoterState.VoterId`/`VotedForId` are still `byte`.

Also adds `2026.8.18` to `supportedAU`, which this branch is still missing — without it the main menu shows the "incompatible versions" popup and the version in red.

### Known limitation

The `CheckForEndVoting` prefix (VoteImmune) reimplements the method and does not replay v18's Judge vote-overrules, so it passes `wasOverruled: false, overruleNonce: 0`. Replicating the real behaviour needs `TryGetWinningOverrule`, which is private and has no body in the reference assemblies. Flagging it since Judge interactions may not have been looked at yet.

### Second commit (optional)

`Add a Hide Console toggle to the Modes tab` is independent of the fix and can be dropped if unwanted. It adds a `Hide Console` tickbox next to Stealth/Panic that shows or hides the BepInEx console window via `ConsoleManager`. It also means Panic Mode closes the console, which it previously left open. Unrelated to the in-game console from #881.

### Testing

Both commits build cleanly, and each builds standalone. Ran in-game on Among Us `2026.8.18` across several rounds including a Judge game: plugin loads, all Harmony patches bind, `ErrorLog.log` empty, no exceptions from the mod. I also verified every by-name Harmony parameter injection (`chatText`, `srcClient`, `shouldAnimate`, etc.) still matches the v18 signatures, since those fail at runtime rather than at build time.

Related: #884
