### PR TITLE
Fix compile errors from the 2026.8.18 bump

### DIFF
--- a/src/Cheats/MalumCheats.cs
+++ b/src/Cheats/MalumCheats.cs
@@ -26,7 +26,7 @@ public static class MalumCheats
             PlayerControl.LocalPlayer.SetKillTimer(GameManager.Instance.LogicOptions.GetKillCooldown());
             ShipStatus.Instance.EmergencyCooldown = GameManager.Instance.LogicOptions.GetEmergencyCooldown();
             Camera.main.GetComponent<FollowerCamera>().Locked = false;
-            DestroyableSingleton<HudManager>.Instance.SetMapButtonEnabled(true);
+            DestroyableSingleton<HudManager>.Instance.SetMapAndInfoButtonsEnabled(true);
             DestroyableSingleton<HudManager>.Instance.SetHudActive(true);
             ControllerManager.Instance.CloseAndResetAll();
 
@@ -46,7 +46,7 @@ public static class MalumCheats
 
         if (Utils.isMeeting)
         {
-            MeetingHud.Instance.RpcVotingComplete(new Il2CppStructArray<MeetingHud.VoterState>(0L), null, true);
+            MeetingHud.Instance.RpcVotingComplete(new Il2CppStructArray<MeetingHud.VoterState>(0L), null, true, false, 0);
         }
 
         CheatToggles.skipMeeting = false;

--- a/src/Cheats/MalumESP.cs
+++ b/src/Cheats/MalumESP.cs
@@ -84,7 +84,7 @@ public static class MalumESP
             foreach (var playerState in meetingHud.playerStates)
             {
                 // Fetch the NetworkedPlayerInfo of each playerState
-                var data = GameData.Instance.GetPlayerById(playerState.TargetPlayerId);
+                var data = GameData.Instance.GetPlayerById(playerState.PlayerId);
 
                 if (data.IsNull() || data.Disconnected || data.Outfits[PlayerOutfitType.Default].IsNull()) continue;
 

--- a/src/Cheats/MalumPPMCheats.cs
+++ b/src/Cheats/MalumPPMCheats.cs
@@ -90,7 +90,7 @@ public static class MalumPPMCheats
                 PlayerPickMenu.OpenPlayerPickMenu(playerInfo, (Action)(() =>
                 {
                     NetworkedPlayerInfo playerToEject = PlayerPickMenu.targetPlayerData;
-                    MeetingHud.Instance.RpcVotingComplete(new Il2CppStructArray<MeetingHud.VoterState>(0L), playerToEject, false);
+                    MeetingHud.Instance.RpcVotingComplete(new Il2CppStructArray<MeetingHud.VoterState>(0L), playerToEject, false, false, 0);
                 }));
 
                 _ejectPlayerActive = true;

--- a/src/MalumMenu.cs
+++ b/src/MalumMenu.cs
@@ -35,6 +35,9 @@ public partial class MalumMenu : BasePlugin
     public static bool isPanicked = false;
     public static bool inStealthMode = false;
 
+    // Set to true to hide the console window
+    public static bool hideConsoleWindow = true;
+
     public static ConfigEntry<string> menuKeybind;
     public static ConfigEntry<string> menuHtmlColor;
     public static ConfigEntry<bool> menuOpenOnMouse;
@@ -58,6 +61,8 @@ public partial class MalumMenu : BasePlugin
     {
         Log = base.Log;
         Plugin = this;
+
+        ApplyConsoleVisibility();
 
         // Loads config settings
         menuKeybind = Config.Bind("MalumMenu.GUI",
@@ -227,5 +232,25 @@ public partial class MalumMenu : BasePlugin
                 }
             }
         }));
+    }
+
+    // Shows or hides the console window based on hideConsoleWindow
+    public static void ApplyConsoleVisibility()
+    {
+        try
+        {
+            if (!hideConsoleWindow && !ConsoleManager.ConsoleActive)
+            {
+                ConsoleManager.CreateConsole();
+            }
+            else if (hideConsoleWindow && ConsoleManager.ConsoleActive)
+            {
+                ConsoleManager.DetachConsole();
+            }
+        }
+        catch (Exception ex)
+        {
+            Log.LogWarning($"Could not apply console visibility: {ex.Message}");
+        }
     }
 }

--- a/src/MalumMenu.cs
+++ b/src/MalumMenu.cs
@@ -31,7 +31,7 @@ public partial class MalumMenu : BasePlugin
     public static KeybindListener keybindListener;
 
     public static string malumVersion = "3.2.0";
-    public static List<string> supportedAU = new List<string> { "2026.6.5", "2026.3.31" };
+    public static List<string> supportedAU = new List<string> { "2026.8.18", "2026.6.5", "2026.3.31" };
     public static bool isPanicked = false;
     public static bool inStealthMode = false;
 

--- a/src/Patches/MeetingHudPatches.cs
+++ b/src/Patches/MeetingHudPatches.cs
@@ -13,23 +13,23 @@ public static class MeetingHud_Update
     // Prefix patch of MeetingHud.Update to constantly bloop new vote icons for each new vote being cast during the meeting
     public static void Prefix(MeetingHud __instance)
     {
-        if (__instance.state < MeetingHud.VoteStates.Results)
+        if (__instance.state < MeetingHud.MeetingStates.Results)
         {
             foreach (var playerVoteArea in __instance.playerStates)
             {
                 if (!playerVoteArea) continue;
 
-                var playerData = GameData.Instance.GetPlayerById(playerVoteArea.TargetPlayerId);
+                var playerData = GameData.Instance.GetPlayerById(playerVoteArea.PlayerId);
 
-                if (playerData != null && !playerData.Disconnected && playerVoteArea.VotedFor != PlayerVoteArea.HasNotVoted && playerVoteArea.VotedFor != PlayerVoteArea.MissedVote && playerVoteArea.VotedFor != PlayerVoteArea.DeadVote && !votedPlayers.Contains(playerVoteArea.TargetPlayerId))
+                if (playerData != null && !playerData.Disconnected && playerVoteArea.VotedForId != PlayerVoteArea.HasNotVoted && playerVoteArea.VotedForId != PlayerVoteArea.MissedVote && playerVoteArea.VotedForId != PlayerVoteArea.DeadVote && !votedPlayers.Contains(playerVoteArea.PlayerId))
                 {
-                    votedPlayers.Add(playerVoteArea.TargetPlayerId);
+                    votedPlayers.Add(playerVoteArea.PlayerId);
 
-                    if (playerVoteArea.VotedFor != PlayerVoteArea.SkippedVote)
+                    if (playerVoteArea.VotedForId != PlayerVoteArea.SkippedVote)
                     {
                         foreach (var votedForArea in __instance.playerStates)
                         {
-                            if (votedForArea.TargetPlayerId == playerVoteArea.VotedFor)
+                            if (votedForArea.PlayerId == playerVoteArea.VotedForId)
                             {
                                 __instance.BloopAVoteIcon(playerData, 0, votedForArea.transform);
                                 break;
@@ -139,12 +139,13 @@ public static class MeetingHud_CheckForEndVoting
             var playerState = __instance.playerStates[index];
             states[index] = new MeetingHud.VoterState
             {
-                VoterId = playerState.TargetPlayerId,
-                VotedForId = playerState.VotedFor
+                VoterId = playerState.PlayerId,
+                VotedForId = playerState.VotedForId
             };
         }
 
-        __instance.RpcVotingComplete(states, exiled, tie);
+        // Judge vote-overrules are not replayed here
+        __instance.RpcVotingComplete(states, exiled, tie, false, 0);
 
         return false;
     }

--- a/src/Utilities/Utils.cs
+++ b/src/Utilities/Utils.cs
@@ -32,8 +32,8 @@ public static class Utils
     public static bool isHost => AmongUsClient.Instance && AmongUsClient.Instance.AmHost;
     public static bool isInGame => AmongUsClient.Instance && AmongUsClient.Instance.GameState == InnerNetClient.GameStates.Started && isPlayer;
     public static bool isMeeting => MeetingHud.Instance;
-    public static bool isMeetingVoting => isMeeting && MeetingHud.Instance.state is MeetingHud.VoteStates.Voted or MeetingHud.VoteStates.NotVoted;
-    public static bool isMeetingProceeding => isMeeting && MeetingHud.Instance.state is MeetingHud.VoteStates.Proceeding;
+    public static bool isMeetingVoting => isMeeting && MeetingHud.Instance.state is MeetingHud.MeetingStates.Voted or MeetingHud.MeetingStates.NotVoted;
+    public static bool isMeetingProceeding => isMeeting && MeetingHud.Instance.state is MeetingHud.MeetingStates.Proceeding;
     public static bool isExiling => ExileController.Instance && !(isAirshipMap && SpawnInMinigame.Instance.isActiveAndEnabled);
     public static bool isAnySabotageActive => ShipStatus.Instance && SabotageSystem.AnyActive;
     public static bool isNormalGame => GameOptionsManager.Instance.CurrentGameOptions.GameMode == GameModes.Normal;


### PR DESCRIPTION
Fixes the v18 renames (VoteStates, TargetPlayerId, VotedFor, SetMapButtonEnabled) and the two new RpcVotingComplete args so this compiles again, plus a toggle to hide the console you can drop