### PR TITLE
Among Us v18.0.0 compatibility update

### DIFF
--- a/src/Cheats/MalumCheats.cs
+++ b/src/Cheats/MalumCheats.cs
@@ -26,7 +26,7 @@ public static class MalumCheats
             PlayerControl.LocalPlayer.SetKillTimer(GameManager.Instance.LogicOptions.GetKillCooldown());
             ShipStatus.Instance.EmergencyCooldown = GameManager.Instance.LogicOptions.GetEmergencyCooldown();
             Camera.main.GetComponent<FollowerCamera>().Locked = false;
-            DestroyableSingleton<HudManager>.Instance.SetMapButtonEnabled(true);
+            DestroyableSingleton<HudManager>.Instance.SetMapAndInfoButtonsEnabled(true);
             DestroyableSingleton<HudManager>.Instance.SetHudActive(true);
             ControllerManager.Instance.CloseAndResetAll();
 
@@ -46,7 +46,7 @@ public static class MalumCheats
 
         if (Utils.isMeeting)
         {
-            MeetingHud.Instance.RpcVotingComplete(new Il2CppStructArray<MeetingHud.VoterState>(0L), null, true);
+            MeetingHud.Instance.RpcVotingComplete(new Il2CppStructArray<MeetingHud.VoterState>(0L), null, true, false, ushort.MinValue);
         }
 
         CheatToggles.skipMeeting = false;

--- a/src/Cheats/MalumESP.cs
+++ b/src/Cheats/MalumESP.cs
@@ -32,8 +32,9 @@ public static class MalumESP
     {
         if (CheatToggles.zoomOut)
         {
-            if (hudManager.Chat.IsOpenOrOpening || PlayerCustomizationMenu.Instance || (Utils.isLobby && (FriendsListUI.Instance.IsOpen ||
-                GameStartManager.Instance.LobbyInfoPane.LobbyViewSettingsPane.gameObject.active || GameStartManager.Instance.RulesEditPanel))) return;
+            // Suspend zoomOut whenever a UI screen requires scrolling
+            if (hudManager.Chat.IsOpenOrOpening || MatchInfoGuide.Instance.IsActive || PlayerCustomizationMenu.Instance ||
+            (Utils.isLobby && (FriendsListUI.Instance.IsOpen || GameStartManager.Instance.LobbyInfoPane.LobbyViewSettingsPane.gameObject.active || GameStartManager.Instance.RulesEditPanel))) return;
 
             _resolutionChangeNeeded = true;
 

--- a/src/Cheats/MalumESP.cs
+++ b/src/Cheats/MalumESP.cs
@@ -84,7 +84,7 @@ public static class MalumESP
             foreach (var playerState in meetingHud.playerStates)
             {
                 // Fetch the NetworkedPlayerInfo of each playerState
-                var data = GameData.Instance.GetPlayerById(playerState.TargetPlayerId);
+                var data = GameData.Instance.GetPlayerById(playerState.PlayerId);
 
                 if (data.IsNull() || data.Disconnected || data.Outfits[PlayerOutfitType.Default].IsNull()) continue;
 

--- a/src/Cheats/MalumPPMCheats.cs
+++ b/src/Cheats/MalumPPMCheats.cs
@@ -90,7 +90,7 @@ public static class MalumPPMCheats
                 PlayerPickMenu.OpenPlayerPickMenu(playerInfo, (Action)(() =>
                 {
                     NetworkedPlayerInfo playerToEject = PlayerPickMenu.targetPlayerData;
-                    MeetingHud.Instance.RpcVotingComplete(new Il2CppStructArray<MeetingHud.VoterState>(0L), playerToEject, false);
+                    MeetingHud.Instance.RpcVotingComplete(new Il2CppStructArray<MeetingHud.VoterState>(0L), playerToEject, false, false, ushort.MinValue);
                 }));
 
                 _ejectPlayerActive = true;

--- a/src/Patches/MeetingHudPatches.cs
+++ b/src/Patches/MeetingHudPatches.cs
@@ -13,23 +13,23 @@ public static class MeetingHud_Update
     // Prefix patch of MeetingHud.Update to constantly bloop new vote icons for each new vote being cast during the meeting
     public static void Prefix(MeetingHud __instance)
     {
-        if (__instance.state < MeetingHud.VoteStates.Results)
+        if (__instance.state < MeetingHud.MeetingStates.Results)
         {
             foreach (var playerVoteArea in __instance.playerStates)
             {
                 if (!playerVoteArea) continue;
 
-                var playerData = GameData.Instance.GetPlayerById(playerVoteArea.TargetPlayerId);
+                var playerData = GameData.Instance.GetPlayerById(playerVoteArea.PlayerId);
 
-                if (playerData != null && !playerData.Disconnected && playerVoteArea.VotedFor != PlayerVoteArea.HasNotVoted && playerVoteArea.VotedFor != PlayerVoteArea.MissedVote && playerVoteArea.VotedFor != PlayerVoteArea.DeadVote && !votedPlayers.Contains(playerVoteArea.TargetPlayerId))
+                if (playerData != null && !playerData.Disconnected && playerVoteArea.VotedForId != PlayerVoteArea.HasNotVoted && playerVoteArea.VotedForId != PlayerVoteArea.MissedVote && playerVoteArea.VotedForId != PlayerVoteArea.DeadVote && !votedPlayers.Contains(playerVoteArea.PlayerId))
                 {
-                    votedPlayers.Add(playerVoteArea.TargetPlayerId);
+                    votedPlayers.Add(playerVoteArea.PlayerId);
 
-                    if (playerVoteArea.VotedFor != PlayerVoteArea.SkippedVote)
+                    if (playerVoteArea.VotedForId != PlayerVoteArea.SkippedVote)
                     {
                         foreach (var votedForArea in __instance.playerStates)
                         {
-                            if (votedForArea.TargetPlayerId == playerVoteArea.VotedFor)
+                            if (votedForArea.PlayerId == playerVoteArea.VotedForId)
                             {
                                 __instance.BloopAVoteIcon(playerData, 0, votedForArea.transform);
                                 break;
@@ -126,6 +126,27 @@ public static class MeetingHud_CheckForEndVoting
         var max = __instance.CalculateVotes().MaxPair(out var tie);
         var exiled = GameData.Instance.AllPlayers.ToArray().FirstOrDefault(v => !tie && v.PlayerId == max.Key);
 
+        bool wasOverruled = false;
+        ushort overruleNonce = 0;
+        JudgeOverrule judgeOverrule;
+        NetworkedPlayerInfo networkedPlayerInfo;
+        NetworkedPlayerInfo networkedPlayerInfo2;
+
+        if (__instance.TryGetWinningOverrule(out judgeOverrule, out networkedPlayerInfo, out networkedPlayerInfo2))
+        {
+            wasOverruled = true;
+            overruleNonce = judgeOverrule.OverruleNonce;
+
+            if (networkedPlayerInfo2.Role.TeamType == RoleTeamTypes.Impostor)
+            {
+                exiled = GameData.Instance.GetPlayerById(judgeOverrule.OverruledPlayerId);
+            }
+            else
+            {
+                exiled = networkedPlayerInfo;
+            }
+        }
+
         // This is the only change from the original method - make sure local player is not exiled
         if (exiled != null && exiled == PlayerControl.LocalPlayer.Data)
         {
@@ -139,12 +160,12 @@ public static class MeetingHud_CheckForEndVoting
             var playerState = __instance.playerStates[index];
             states[index] = new MeetingHud.VoterState
             {
-                VoterId = playerState.TargetPlayerId,
-                VotedForId = playerState.VotedFor
+                VoterId = playerState.PlayerId,
+                VotedForId = playerState.VotedForId
             };
         }
 
-        __instance.RpcVotingComplete(states, exiled, tie);
+        __instance.RpcVotingComplete(states, exiled, tie, wasOverruled, overruleNonce);
 
         return false;
     }

--- a/src/Patches/OtherPatches.cs
+++ b/src/Patches/OtherPatches.cs
@@ -417,13 +417,30 @@ public static class BanMenu_SetVisible
 public static class IGameOptionsExtensions_GetAdjustedNumImpostors
 {
     // Prefix patch of IGameOptionsExtensions.GetAdjustedNumImpostors to remove impostor limits
-    public static bool Prefix(IGameOptions __instance, ref int __result)
+    public static bool Prefix(ref int __result)
     {
         if (!CheatToggles.noOptionsLimits) return true;
 
         __result = GameOptionsManager.Instance.CurrentGameOptions.NumImpostors;
 
         return false;
+    }
+}
+
+[HarmonyPatch(typeof(MatchInfoHudButton), nameof(MatchInfoHudButton.Update))]
+public static class MatchInfoHudButton_Update
+{
+    // Prefix patch of MatchInfoHudButton.Update to prevent the MatchInfo and Chat buttons from overlapping
+    public static bool Prefix(MatchInfoHudButton __instance)
+    {
+        if (CheatToggles.enableChat)
+        {
+            __instance.aspectPosition.DistanceFromEdge = MatchInfoHudButton.adjustedDistanceFromEdge;
+
+            return false;
+        }
+
+        return true;
     }
 }
 

--- a/src/Utilities/Utils.cs
+++ b/src/Utilities/Utils.cs
@@ -32,8 +32,8 @@ public static class Utils
     public static bool isHost => AmongUsClient.Instance && AmongUsClient.Instance.AmHost;
     public static bool isInGame => AmongUsClient.Instance && AmongUsClient.Instance.GameState == InnerNetClient.GameStates.Started && isPlayer;
     public static bool isMeeting => MeetingHud.Instance;
-    public static bool isMeetingVoting => isMeeting && MeetingHud.Instance.state is MeetingHud.VoteStates.Voted or MeetingHud.VoteStates.NotVoted;
-    public static bool isMeetingProceeding => isMeeting && MeetingHud.Instance.state is MeetingHud.VoteStates.Proceeding;
+    public static bool isMeetingVoting => isMeeting && MeetingHud.Instance.state is MeetingHud.MeetingStates.Voted or MeetingHud.MeetingStates.NotVoted;
+    public static bool isMeetingProceeding => isMeeting && MeetingHud.Instance.state is MeetingHud.MeetingStates.Proceeding;
     public static bool isExiling => ExileController.Instance && !(isAirshipMap && SpawnInMinigame.Instance.isActiveAndEnabled);
     public static bool isAnySabotageActive => ShipStatus.Instance && SabotageSystem.AnyActive;
     public static bool isNormalGame => GameOptionsManager.Instance.CurrentGameOptions.GameMode == GameModes.Normal;


### PR DESCRIPTION
- **Fix**: Update the source code to match changes introduced in Among Us v18.0.0
- **Fix**: Prevent the MatchInfo and Chat buttons from overlapping when AlwaysChat is enabled
- **Fix**: Suspend ZoomOut while the MatchInfoGuide UI is open to prevent annoyances when scrolling