### PR TITLE
Add Judge to fakeRole

### DIFF
--- a/src/Cheats/MalumPPMCheats.cs
+++ b/src/Cheats/MalumPPMCheats.cs
@@ -283,6 +283,13 @@ public static class MalumPPMCheats
                     playerDataList.Add(PlayerPickMenu.CustomPPMChoice("Impostor", OutfitPreset.Impostor, Utils.GetBehaviourByRoleType(RoleTypes.Impostor)));
                 }
 
+                // Judge role can only be used if it was already assigned at the start of the game
+                // This is done to prevent the anticheat from kicking players
+                if (_oldRole == RoleTypes.Judge || Utils.isFreePlay)
+                {
+                    playerDataList.Add(PlayerPickMenu.CustomPPMChoice("Judge", OutfitPreset.Judge, Utils.GetBehaviourByRoleType(RoleTypes.Judge)));
+                }
+
                 playerDataList.Add(PlayerPickMenu.CustomPPMChoice("Tracker", OutfitPreset.Tracker, Utils.GetBehaviourByRoleType(RoleTypes.Tracker)));
                 playerDataList.Add(PlayerPickMenu.CustomPPMChoice("Noisemaker", OutfitPreset.Noisemaker, Utils.GetBehaviourByRoleType(RoleTypes.Noisemaker)));
                 playerDataList.Add(PlayerPickMenu.CustomPPMChoice("Engineer", OutfitPreset.Engineer, Utils.GetBehaviourByRoleType(RoleTypes.Engineer)));

--- a/src/Utilities/OutfitPreset.cs
+++ b/src/Utilities/OutfitPreset.cs
@@ -40,6 +40,12 @@ public static class OutfitPreset
         SkinId = "skin_rhm"
     };
 
+    public static NetworkedPlayerInfo.PlayerOutfit Judge = new()
+    {
+        ColorId = 10,
+        HatId = "hat_wigJudge",
+    };
+
     public static NetworkedPlayerInfo.PlayerOutfit Noisemaker = new()
     {
         ColorId = 10,


### PR DESCRIPTION
- **Feat**: Add Judge option to fakeRole list
  - Only accessible if the role was already assigned at the start of the game
  - This is put in place as, otherwise, using its ability leads to AC kick (for both host and non-host)