### PR TITLE
Bump Malum version from v3.2.0 to v3.3.0

### DIFF
--- a/README.md
+++ b/README.md
@@ -39,6 +39,7 @@
 
 | Mod Version| Among Us - Version | Link |
 |----------|-------------|-----------------|
+| v3.3.0 | 18 ( 2026.8.18 ) | [Download](https://github.com/scp222thj/MalumMenu/releases/tag/v3.3.0) |
 | v3.2.0 | 17.4 ( 2026.6.5 )<br>17.3 ( 2026.3.31 ) | [Download](https://github.com/scp222thj/MalumMenu/releases/tag/v3.2.0) |
 | v3.1.1 | 17.3 ( 2026.3.31 ) | [Download](https://github.com/scp222thj/MalumMenu/releases/tag/v3.1.1) |
 | v3.1.0 | 17.3 ( 2026.3.31 ) | [Download](https://github.com/scp222thj/MalumMenu/releases/tag/v3.1.0) |
@@ -137,7 +138,7 @@ Click to expand each topic
 
 <summary><h2>❗ I'm having issues installing MalumMenu</h2></summary>
 
-First of all, make sure you are running the most recent version of Among Us (`17.4` / `2026.6.5` OR `17.3` / `2026.3.31`) with the most recent version of MalumMenu (`v3.2.0`).
+First of all, make sure you are running the most recent version of Among Us (`18` / `2026.8.18`) with the most recent version of MalumMenu (`v3.3.0`).
 
 Also, check if your platform is officially supported:
 

--- a/src/MalumMenu.cs
+++ b/src/MalumMenu.cs
@@ -31,7 +31,7 @@ public partial class MalumMenu : BasePlugin
     public static KeybindListener keybindListener;
 
     public static string malumVersion = "3.2.0";
-    public static List<string> supportedAU = new List<string> { "2026.6.5", "2026.3.31" };
+    public static List<string> supportedAU = new List<string> { "2026.8.18" };
     public static bool isPanicked = false;
     public static bool inStealthMode = false;
 

--- a/src/MalumMenu.cs
+++ b/src/MalumMenu.cs
@@ -30,7 +30,7 @@ public partial class MalumMenu : BasePlugin
     public static ProtectUI protectUI;
     public static KeybindListener keybindListener;
 
-    public static string malumVersion = "3.2.0";
+    public static string malumVersion = "3.3.0";
     public static List<string> supportedAU = new List<string> { "2026.8.18" };
     public static bool isPanicked = false;
     public static bool inStealthMode = false;

--- a/src/MalumMenu.csproj
+++ b/src/MalumMenu.csproj
@@ -4,7 +4,7 @@
         <LangVersion>latest</LangVersion>
         <DebugType>embedded</DebugType>
 
-        <VersionPrefix>3.2.0</VersionPrefix>
+        <VersionPrefix>3.3.0</VersionPrefix>
         <Description>all play and no cheats makes among us a dull game</Description>
         <Authors>scp222thj, astra1dev</Authors>
     </PropertyGroup>


### PR DESCRIPTION
- **Chore**: Set 2026.8.18 as the only supported AU version (due to naming changes in v18)
- **Chore**: Bump Malum version from v3.2.0 to v3.3.0
- **Docs**: Add v3.3.0 to README