### PR TITLE
Block kill RPC while in lobby instead of restricting fake role

### DIFF
--- a/src/Patches/PlayerControlPatches.cs
+++ b/src/Patches/PlayerControlPatches.cs
@@ -47,11 +47,7 @@ public static class PlayerControl_CmdCheckMurder
         return false;*/
 
         if (!Utils.isHost) return true;
-        if (Utils.isLobby)
-{
-            HudManager.Instance.Notifier.AddDisconnectMessage("Killing in lobby disabled for being too buggy");
-            return false;
-}
+
         // __instance.isKilling = true;
         PlayerControl.LocalPlayer.RpcMurderPlayer(target, true);
 

--- a/src/Patches/PlayerControlPatches.cs
+++ b/src/Patches/PlayerControlPatches.cs
@@ -47,7 +47,11 @@ public static class PlayerControl_CmdCheckMurder
         return false;*/
 
         if (!Utils.isHost) return true;
-
+        if (Utils.isLobby)
+{
+            HudManager.Instance.Notifier.AddDisconnectMessage("Killing in lobby disabled for being too buggy");
+            return false;
+}
         // __instance.isKilling = true;
         PlayerControl.LocalPlayer.RpcMurderPlayer(target, true);
 

--- a/src/Patches/PlayerControlPatches.cs
+++ b/src/Patches/PlayerControlPatches.cs
@@ -47,6 +47,11 @@ public static class PlayerControl_CmdCheckMurder
         return false;*/
 
         if (!Utils.isHost) return true;
+		if (Utils.isLobby)
+{
+    HudManager.Instance.Notifier.AddDisconnectMessage("Killing in lobby disabled for being too buggy");
+    return false;
+}
 
         // __instance.isKilling = true;
         PlayerControl.LocalPlayer.RpcMurderPlayer(target, true);

--- a/src/UI/Windows/Tabs/ShipTab.cs
+++ b/src/UI/Windows/Tabs/ShipTab.cs
@@ -48,23 +48,6 @@ public class ShipTab : ITab
     {
         GUILayout.Label("Sabotage", GUIStylePreset.TabSubtitle);
 
-        if (GUILayout.Button("Sabotage All"))
-{
-    CheatToggles.reactorSab = true;
-    CheatToggles.oxygenSab = true;
-    CheatToggles.elecSab = true;
-    CheatToggles.commsSab = true;
-    CheatToggles.mushSab = true;
-}
-
-if (GUILayout.Button("Repair All"))
-{
-    CheatToggles.reactorSab = false;
-    CheatToggles.oxygenSab = false;
-    CheatToggles.elecSab = false;
-    CheatToggles.commsSab = false;
-}
-
         CheatToggles.reactorSab = GUILayout.Toggle(CheatToggles.reactorSab, " Reactor");
 
         CheatToggles.oxygenSab = GUILayout.Toggle(CheatToggles.oxygenSab, " Oxygen");

--- a/src/UI/Windows/Tabs/ShipTab.cs
+++ b/src/UI/Windows/Tabs/ShipTab.cs
@@ -48,6 +48,23 @@ public class ShipTab : ITab
     {
         GUILayout.Label("Sabotage", GUIStylePreset.TabSubtitle);
 
+        if (GUILayout.Button("Sabotage All"))
+{
+    CheatToggles.reactorSab = true;
+    CheatToggles.oxygenSab = true;
+    CheatToggles.elecSab = true;
+    CheatToggles.commsSab = true;
+    CheatToggles.mushSab = true;
+}
+
+if (GUILayout.Button("Repair All"))
+{
+    CheatToggles.reactorSab = false;
+    CheatToggles.oxygenSab = false;
+    CheatToggles.elecSab = false;
+    CheatToggles.commsSab = false;
+}
+
         CheatToggles.reactorSab = GUILayout.Toggle(CheatToggles.reactorSab, " Reactor");
 
         CheatToggles.oxygenSab = GUILayout.Toggle(CheatToggles.oxygenSab, " Oxygen");


### PR DESCRIPTION
related to #573 that pr blocks setting fake role to imposter in lobby to prevent the kick, this one takes the other approach **"scp222thj"** mentioned in that thread (blocking kills from being sent in lobby instead of blocking fake role) 

the actual kick happens because PlayerControl_CmdCheckMurder sends RpcMurderPlayer directly with no check for lobby state so the server kicks you for an "invalid" action during that game state there already a Utils.isLobby guard used for the exact same problem in KillAllCheat (with the same disconnect message) it just wasn’t applied here the same check used to be here too just commented out.

fix: added the isLobby check back before the kill RPC gets sent same message and pattern as KillAllCheat uses tested by hosting a lobby setting fake role to impostor and trying to kill in lobby now shows the notifier message instead of getting kicked

<img width="647" height="81" alt="photo_2026-08-28_11-46-27" src="https://github.com/user-attachments/assets/5e1e095e-edd1-4ee7-bb77-39705cd4ad55" />