### PR TITLE
Added Sabotage All & Repair All buttons in ship tab

### DIFF
--- a/src/UI/Windows/Tabs/ShipTab.cs
+++ b/src/UI/Windows/Tabs/ShipTab.cs
@@ -47,6 +47,22 @@ public class ShipTab : ITab
     private void DrawSabotage()
     {
         GUILayout.Label("Sabotage", GUIStylePreset.TabSubtitle);
+        if (GUILayout.Button("Sabotage All"))
+{
+    CheatToggles.reactorSab = true;
+    CheatToggles.oxygenSab = true;
+    CheatToggles.elecSab = true;
+    CheatToggles.commsSab = true;
+    CheatToggles.mushSab = true;
+}
+
+        if (GUILayout.Button("Repair All"))
+{
+    CheatToggles.reactorSab = false;
+    CheatToggles.oxygenSab = false;
+    CheatToggles.elecSab = false;
+    CheatToggles.commsSab = false;
+}
 
         CheatToggles.reactorSab = GUILayout.Toggle(CheatToggles.reactorSab, " Reactor");
 


### PR DESCRIPTION
added two buttons to the Sabotage section (Ship tab) to trigger/repair every sabotage at once instead of toggling each one 
<img width="317" height="96" alt="image" src="https://github.com/user-attachments/assets/be0f7ed3-fdfa-4fbd-a42a-c262047d3efa" />
